### PR TITLE
Lf fix

### DIFF
--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -627,9 +627,9 @@ void MoveStructure::build(std::ifstream &bwt_file) {
                 pp_id += 1;
             
 
-            if (pp_id == 0) {
-                offset = 0;
-            } else {
+            // if (pp_id == 0) {
+            //     offset = 0;
+            // } else {
                 // check the boundaries before performing select
                 if (pp_id >= r) {
                     std::cerr << "pp_id: " << pp_id << "r: " << r << "i: " << i << "bwt_row: " << bwt_row << "lf: " << lf << "\n";
@@ -641,7 +641,7 @@ void MoveStructure::build(std::ifstream &bwt_file) {
                 }
 
                 offset = lf - sbits(pp_id + 1);
-            }
+            // }
             if (verbose and r_idx == 0) // or any run to be inspected
                 std::cerr << "r_idx: " << r_idx 
                           << " bwt_row: " << bwt_row

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -625,23 +625,18 @@ void MoveStructure::build(std::ifstream &bwt_file) {
             uint64_t pp_id = rbits(lf) - 1;
             if (bits[lf] == 1)
                 pp_id += 1;
-            
 
-            // if (pp_id == 0) {
-            //     offset = 0;
-            // } else {
-                // check the boundaries before performing select
-                if (pp_id >= r) {
-                    std::cerr << "pp_id: " << pp_id << "r: " << r << "i: " << i << "bwt_row: " << bwt_row << "lf: " << lf << "\n";
-                    exit(0);
-                }
-                if (lf < sbits(pp_id + 1)) {
-                    std::cerr << lf << " " << sbits(pp_id + 1);
-                    exit(0);
-                }
+            // check the boundaries before performing select
+            if (pp_id >= r) {
+                std::cerr << "pp_id: " << pp_id << "r: " << r << "i: " << i << "bwt_row: " << bwt_row << "lf: " << lf << "\n";
+                exit(0); // TODO: add error handling
+            }
+            if (lf < sbits(pp_id + 1)) {
+                std::cerr << lf << " " << sbits(pp_id + 1);
+                exit(0); // TODO: add error handling
+            }
+            offset = lf - sbits(pp_id + 1);
 
-                offset = lf - sbits(pp_id + 1);
-            // }
             if (verbose and r_idx == 0) // or any run to be inspected
                 std::cerr << "r_idx: " << r_idx 
                           << " bwt_row: " << bwt_row


### PR DESCRIPTION
This was a fix for the LF_move operation. It was storing the wrong offset when the id column was equal to 0. The new code is tested on several indexes including the Zymo index and I verified that the LF reconstruction also works.