### PR TITLE
Row optimization

### DIFF
--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -68,15 +68,14 @@ class MoveRow{
 #endif
         }
     private:
-        uint32_t id; // bwt run after the jump
+        uint32_t id; // bwt run after the LF-jump
         uint16_t n; // length of the run
-        uint16_t offset; // offset of the bwt row head of the current run in the new run after the jump
+        uint16_t offset; // offset of the bwt row head of the current run in the new run after the LF-jump
         uint16_t threshold;
-
         uint8_t overflow_bits;
-        // thresholds for all the rows:
+
 #if MODE == 0 or MODE == 1
-        uint8_t thresholds_status;
+        uint8_t thresholds_status; // Whether each threshold is at the boundary or it's a non-trivial value
 #endif
 
 #if MODE == 1

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -9,20 +9,15 @@
 // #define MODE -1// 0: regular, 1: constant, 2: one-bit
 // #endif
 
-// const uint32_t mask_p = ~((1U << 8) - 1);
-// const uint32_t mask_pp = ~(((1U << 8) - 1) << 8);
-// const uint32_t mask_id = ~(((1U << 8) - 1) << 16);
-// const uint32_t mask_c = ~(((1U << 8) - 1) << 24);
+const uint16_t mask_thresholds1 = static_cast<uint16_t>(~(((1U << 2) - 1) << 0)); // 00000011
+const uint16_t mask_thresholds2 = static_cast<uint16_t>(~(((1U << 2) - 1) << 2)); // 00001100
+const uint16_t mask_thresholds3 = static_cast<uint16_t>(~(((1U << 2) - 1) << 4)); // 00110000
 
-const uint16_t mask_thresholds1 = static_cast<uint16_t>(~(((1U << 2) - 1) << 0));
-const uint16_t mask_thresholds2 = static_cast<uint16_t>(~(((1U << 2) - 1) << 2));
-const uint16_t mask_thresholds3 = static_cast<uint16_t>(~(((1U << 2) - 1) << 4));
-
-const uint16_t mask_id =  static_cast<uint16_t>(~((1U << 8) - 1));
-const uint16_t mask_c = static_cast<uint16_t>(~(((1U << 2) - 1) << 8));
-const uint16_t mask_overflow_n = static_cast<uint16_t>(~(((1U << 1) - 1) << 10));
-const uint16_t mask_overflow_offset = static_cast<uint16_t>(~(((1U << 1) - 1) << 11));
-const uint16_t mask_overflow_thresholds = static_cast<uint16_t>(~(((1U << 1) - 1) << 12));
+const uint16_t mask_id =  static_cast<uint16_t>(~(((1U << 8) - 1) << 0));                   // 00000000 11111111
+const uint16_t mask_c = static_cast<uint16_t>(~(((1U << 2) - 1) << 8));                     // 00000011 00000000
+const uint16_t mask_overflow_n = static_cast<uint16_t>(~(((1U << 1) - 1) << 10));           // 00000100 00000000
+const uint16_t mask_overflow_offset = static_cast<uint16_t>(~(((1U << 1) - 1) << 11));      // 00001000 00000000
+const uint16_t mask_overflow_thresholds = static_cast<uint16_t>(~(((1U << 1) - 1) << 12));  // 00010000 00000000
 
 class MoveRow{
     public:
@@ -32,37 +27,25 @@ class MoveRow{
         // void init(uint16_t n_, uint16_t offset_, uint64_t id_, char c_);
         friend std::ostream& operator<<(std::ostream& os, const MoveRow& mr);
 
-        // void set_p(uint64_t p_);
-        // void set_pp(uint64_t pp_);
         void set_n(uint16_t n_);
         void set_offset(uint16_t offset_);
         void set_id(uint64_t id_);
         void set_c(char c_, std::vector<uint64_t>& alphamap);
 
-        // uint64_t get_p() const;
-        // uint64_t get_pp() const;
         uint16_t get_n() const;
         uint16_t get_n_ff() const;
         uint16_t get_offset() const;
         uint64_t get_id() const;
         uint8_t get_threshold_status(uint16_t i) const;
         char get_c() const;
-        char get_c_jj() const;
-        char get_c_mm() const;
 
         void set_overflow_n();
         void set_overflow_offset();
         void set_overflow_thresholds();
         void set_threshold_status(uint16_t i, uint8_t status);
         bool is_overflow_n() const;
-        bool is_overflow_n_ff() const;
         bool is_overflow_offset() const;
         bool is_overflow_thresholds() const;
-
-// #if MODE == 0 or MODE == 1
-//         uint16_t get_thresholds(uint32_t i) { return thresholds[i]; }
-//         void set_thresholds(uint32_t i, uint16_t t) { thresholds[i] = t; }
-// #endif
 
 #if MODE == 1
         uint16_t get_next_up(uint32_t i) { return next_up[i]; }
@@ -71,25 +54,21 @@ class MoveRow{
         void set_next_down(uint32_t i, uint16_t t) { next_down[i] = t; }
 #endif
 
-// #if MODE == 2
         uint16_t get_threshold() { return threshold; }
         void set_threshold(uint16_t t) { threshold = t; }
-// #endif
 
         uint64_t row_size() {
 #if MODE == 0
-            return 16;
+            return 13;
 #endif
 #if MODE == 1
-            return 28;
+            return 25;
 #endif
 #if MODE == 2
             return 12;
 #endif
         }
     private:
-        // offset based: uint32_t p; // bwt row of the head before the jump
-        // offset based: uint32_t pp; // bwt row of the head after the jump
         uint16_t offset; // offset of the bwt row head of the current run in the new run after the jump
         uint16_t overflow_bits;
         uint16_t n; // length of the run
@@ -97,7 +76,6 @@ class MoveRow{
 
         // thresholds for all the rows:
 #if MODE == 0 or MODE == 1
-        // uint16_t thresholds[3];
         uint8_t thresholds_status;
 #endif
 
@@ -107,36 +85,8 @@ class MoveRow{
         uint16_t next_down[3];
 #endif
 
-// #if MODE == 2
-        uint16_t threshold;
-// #endif
+    uint16_t threshold;
 };
-
-/* inline uint64_t MoveRow::get_p() const{
-    /*if (overflow_bits != 0) {
-        uint32_t a = overflow_bits & (~mask_p);
-        uint64_t b = a;
-        b = (b << 32);
-        uint64_t c = p;
-        c = c | b;
-        return c;
-    } else {
-        return static_cast<uint32_t>(p);
-    }
-}*/
-
-/*inline uint64_t MoveRow::get_pp() const{
-    if (overflow_bits != 0) {
-        uint32_t a = (overflow_bits & (~mask_pp)) >> 8;
-        uint64_t b = a;
-        b = (b << 32);
-        uint64_t c = pp;
-        c = c | b;
-        return c;
-    } else {
-        return static_cast<uint32_t>(pp);
-    }
-}*/
 
 inline uint8_t MoveRow::get_threshold_status(uint16_t i) const {
     const uint16_t mask_thresholds = static_cast<uint16_t>(~(((1U << 2) - 1) << i*2));
@@ -156,60 +106,40 @@ inline uint16_t MoveRow::get_offset() const{
     return offset;
 }
 
+inline uint16_t extract_value(uint16_t source, uint16_t mask, uint16_t offset_bits) {
+    uint32_t res = (source & (~mask)) >> offset_bits;
+    return res;
+}
+
 inline uint64_t MoveRow::get_id() const{
     if (overflow_bits != 0) {
-        uint32_t a = overflow_bits & (~mask_id);
-        uint64_t b = a;
-        b = (b << 32);
-        uint64_t c = id;
-        c = c | b;
+        uint64_t res = static_cast<uint64_t>(extract_value(overflow_bits, mask_id, 0));
+        res = res << 32;
+        uint64_t c = static_cast<uint64_t>(id);
+        c = c | res;
         return c;
     } else {
-        return static_cast<uint32_t>(id);
+        return static_cast<uint64_t>(id);
     }
-    return id;
 }
 
 inline char MoveRow::get_c() const{
-    uint8_t a = static_cast<uint8_t>((overflow_bits & (~mask_c)) >> 8);
-    char c = static_cast<char>(a);
-    return c;
-}
-
-inline char MoveRow::get_c_jj() const{
-    uint8_t a = static_cast<uint8_t>((overflow_bits & (~mask_c)) >> 8);
-    char c = static_cast<char>(a);
-    return c;
-}
-
-inline char MoveRow::get_c_mm() const{
-    uint8_t a = static_cast<uint8_t>((overflow_bits & (~mask_c)) >> 8);
-    char c = static_cast<char>(a);
-    return c;
+    return static_cast<char>(extract_value(overflow_bits, mask_c, 8));
 }
 
 inline bool MoveRow::is_overflow_n() const{
-    uint32_t a = (overflow_bits & (~mask_overflow_n)) >> 10;
-    bool b = static_cast<bool>(a);
-    return !b;
-}
-
-inline bool MoveRow::is_overflow_n_ff() const{
-    uint32_t a = (overflow_bits & (~mask_overflow_n)) >> 10;
-    bool b = static_cast<bool>(a);
-    return !b;
+    uint16_t res = extract_value(overflow_bits, mask_overflow_n, 10);
+    return !static_cast<bool>(res);
 }
 
 inline bool MoveRow::is_overflow_offset() const{
-    uint32_t a = (overflow_bits & (~mask_overflow_offset)) >> 11;
-    bool b = static_cast<bool>(a);
-    return !b;
+    uint16_t res = extract_value(overflow_bits, mask_overflow_offset, 11);
+    return !static_cast<bool>(res);
 }
 
 inline bool MoveRow::is_overflow_thresholds() const{
-    uint32_t a = (overflow_bits & (~mask_overflow_thresholds)) >> 12;
-    bool b = static_cast<bool>(a);
-    return !b;
+    uint16_t res = extract_value(overflow_bits, mask_overflow_thresholds, 12);
+    return !static_cast<bool>(res);
 }
 
 #endif

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -9,15 +9,15 @@
 // #define MODE -1// 0: regular, 1: constant, 2: one-bit
 // #endif
 
-const uint16_t mask_thresholds1 = static_cast<uint16_t>(~(((1U << 2) - 1) << 0)); // 00000011
-const uint16_t mask_thresholds2 = static_cast<uint16_t>(~(((1U << 2) - 1) << 2)); // 00001100
-const uint16_t mask_thresholds3 = static_cast<uint16_t>(~(((1U << 2) - 1) << 4)); // 00110000
+const uint8_t mask_thresholds1 = static_cast<uint8_t>(~(((1U << 2) - 1) << 0)); // 00000011
+const uint8_t mask_thresholds2 = static_cast<uint8_t>(~(((1U << 2) - 1) << 2)); // 00001100
+const uint8_t mask_thresholds3 = static_cast<uint8_t>(~(((1U << 2) - 1) << 4)); // 00110000
+const uint8_t mask_c = static_cast<uint8_t>(~(((1U << 2) - 1) << 6));           // 11000000
 
-const uint16_t mask_id =  static_cast<uint16_t>(~(((1U << 8) - 1) << 0));                   // 00000000 11111111
-const uint16_t mask_c = static_cast<uint16_t>(~(((1U << 2) - 1) << 8));                     // 00000011 00000000
-const uint16_t mask_overflow_n = static_cast<uint16_t>(~(((1U << 1) - 1) << 10));           // 00000100 00000000
-const uint16_t mask_overflow_offset = static_cast<uint16_t>(~(((1U << 1) - 1) << 11));      // 00001000 00000000
-const uint16_t mask_overflow_thresholds = static_cast<uint16_t>(~(((1U << 1) - 1) << 12));  // 00010000 00000000
+const uint8_t mask_id =  static_cast<uint8_t>(~(((1U << 4) - 1) << 0));                  // 00001111
+const uint8_t mask_overflow_n = static_cast<uint8_t>(~(((1U << 1) - 1) << 4));           // 00010000
+const uint8_t mask_overflow_offset = static_cast<uint8_t>(~(((1U << 1) - 1) << 5));      // 00100000
+const uint8_t mask_overflow_thresholds = static_cast<uint8_t>(~(((1U << 1) - 1) << 6));  // 01000000
 
 class MoveRow{
     public:
@@ -58,21 +58,22 @@ class MoveRow{
 
         uint64_t row_size() {
 #if MODE == 0
-            return 13;
+            return 12;
 #endif
 #if MODE == 1
-            return 25;
+            return 24;
 #endif
 #if MODE == 2
             return 12;
 #endif
         }
     private:
-        uint16_t offset; // offset of the bwt row head of the current run in the new run after the jump
-        uint16_t overflow_bits;
-        uint16_t n; // length of the run
         uint32_t id; // bwt run after the jump
+        uint16_t n; // length of the run
+        uint16_t offset; // offset of the bwt row head of the current run in the new run after the jump
+        uint16_t threshold;
 
+        uint8_t overflow_bits;
         // thresholds for all the rows:
 #if MODE == 0 or MODE == 1
         uint8_t thresholds_status;
@@ -83,12 +84,10 @@ class MoveRow{
         uint16_t next_up[3];
         uint16_t next_down[3];
 #endif
-
-    uint16_t threshold;
 };
 
 inline uint8_t MoveRow::get_threshold_status(uint16_t i) const {
-    const uint16_t mask_thresholds = static_cast<uint16_t>(~(((1U << 2) - 1) << i*2));
+    const uint8_t mask_thresholds = static_cast<uint8_t>(~(((1U << 2) - 1) << i*2));
     uint8_t status = static_cast<uint8_t>((thresholds_status & (~mask_thresholds)) >> i*2);
     return status;
 }
@@ -105,8 +104,8 @@ inline uint16_t MoveRow::get_offset() const{
     return offset;
 }
 
-inline uint16_t extract_value(uint16_t source, uint16_t mask, uint16_t offset_bits) {
-    uint32_t res = (source & (~mask)) >> offset_bits;
+inline uint8_t extract_value(uint8_t source, uint8_t mask, uint16_t offset_bits) {
+    uint8_t res = (source & (~mask)) >> offset_bits;
     return res;
 }
 
@@ -123,21 +122,21 @@ inline uint64_t MoveRow::get_id() const{
 }
 
 inline char MoveRow::get_c() const{
-    return static_cast<char>(extract_value(overflow_bits, mask_c, 8));
+    return static_cast<char>(extract_value(thresholds_status, mask_c, 6));
 }
 
 inline bool MoveRow::is_overflow_n() const{
-    uint16_t res = extract_value(overflow_bits, mask_overflow_n, 10);
+    uint8_t res = extract_value(overflow_bits, mask_overflow_n, 4);
     return !static_cast<bool>(res);
 }
 
 inline bool MoveRow::is_overflow_offset() const{
-    uint16_t res = extract_value(overflow_bits, mask_overflow_offset, 11);
+    uint8_t res = extract_value(overflow_bits, mask_overflow_offset, 5);
     return !static_cast<bool>(res);
 }
 
 inline bool MoveRow::is_overflow_thresholds() const{
-    uint16_t res = extract_value(overflow_bits, mask_overflow_thresholds, 12);
+    uint8_t res = extract_value(overflow_bits, mask_overflow_thresholds, 6);
     return !static_cast<bool>(res);
 }
 

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -24,7 +24,6 @@ class MoveRow{
         MoveRow () {n = 0; id = 0; overflow_bits = 0;}
         MoveRow(uint16_t n_, uint16_t offset_, uint64_t id_);
         void init(uint16_t n_, uint16_t offset_, uint64_t id_);
-        // void init(uint16_t n_, uint16_t offset_, uint64_t id_, char c_);
         friend std::ostream& operator<<(std::ostream& os, const MoveRow& mr);
 
         void set_n(uint16_t n_);

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -14,6 +14,10 @@
 // const uint32_t mask_id = ~(((1U << 8) - 1) << 16);
 // const uint32_t mask_c = ~(((1U << 8) - 1) << 24);
 
+const uint16_t mask_thresholds1 = static_cast<uint16_t>(~(((1U << 2) - 1) << 0));
+const uint16_t mask_thresholds2 = static_cast<uint16_t>(~(((1U << 2) - 1) << 2));
+const uint16_t mask_thresholds3 = static_cast<uint16_t>(~(((1U << 2) - 1) << 4));
+
 const uint16_t mask_id =  static_cast<uint16_t>(~((1U << 8) - 1));
 const uint16_t mask_c = static_cast<uint16_t>(~(((1U << 2) - 1) << 8));
 const uint16_t mask_overflow_n = static_cast<uint16_t>(~(((1U << 1) - 1) << 10));
@@ -41,6 +45,7 @@ class MoveRow{
         uint16_t get_n_ff() const;
         uint16_t get_offset() const;
         uint64_t get_id() const;
+        uint8_t get_threshold_status(uint16_t i) const;
         char get_c() const;
         char get_c_jj() const;
         char get_c_mm() const;
@@ -48,15 +53,16 @@ class MoveRow{
         void set_overflow_n();
         void set_overflow_offset();
         void set_overflow_thresholds();
+        void set_threshold_status(uint16_t i, uint8_t status);
         bool is_overflow_n() const;
         bool is_overflow_n_ff() const;
         bool is_overflow_offset() const;
         bool is_overflow_thresholds() const;
 
-#if MODE == 0 or MODE == 1
-        uint16_t get_thresholds(uint32_t i) { return thresholds[i]; }
-        void set_thresholds(uint32_t i, uint16_t t) { thresholds[i] = t; }
-#endif
+// #if MODE == 0 or MODE == 1
+//         uint16_t get_thresholds(uint32_t i) { return thresholds[i]; }
+//         void set_thresholds(uint32_t i, uint16_t t) { thresholds[i] = t; }
+// #endif
 
 #if MODE == 1
         uint16_t get_next_up(uint32_t i) { return next_up[i]; }
@@ -65,10 +71,10 @@ class MoveRow{
         void set_next_down(uint32_t i, uint16_t t) { next_down[i] = t; }
 #endif
 
-#if MODE == 2
+// #if MODE == 2
         uint16_t get_threshold() { return threshold; }
         void set_threshold(uint16_t t) { threshold = t; }
-#endif
+// #endif
 
         uint64_t row_size() {
 #if MODE == 0
@@ -91,7 +97,8 @@ class MoveRow{
 
         // thresholds for all the rows:
 #if MODE == 0 or MODE == 1
-        uint16_t thresholds[3];
+        // uint16_t thresholds[3];
+        uint8_t thresholds_status;
 #endif
 
 #if MODE == 1
@@ -100,9 +107,9 @@ class MoveRow{
         uint16_t next_down[3];
 #endif
 
-#if MODE == 2
+// #if MODE == 2
         uint16_t threshold;
-#endif
+// #endif
 };
 
 /* inline uint64_t MoveRow::get_p() const{
@@ -130,6 +137,12 @@ class MoveRow{
         return static_cast<uint32_t>(pp);
     }
 }*/
+
+inline uint8_t MoveRow::get_threshold_status(uint16_t i) const {
+    const uint16_t mask_thresholds = static_cast<uint16_t>(~(((1U << 2) - 1) << i*2));
+    uint8_t status = static_cast<uint8_t>((thresholds_status & (~mask_thresholds)) >> i*2);
+    return status;
+}
 
 inline uint16_t MoveRow::get_n() const{
     return n;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -65,6 +65,7 @@ class MoveStructure {
         void serialize(std::string output_dir);
         void deserialize(std::string index_dir);
         void print_stats();
+        void analyze_rows();
         bool check_alphabet(char c);
 
         std::unordered_map<uint32_t, uint32_t> jumps;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -64,8 +64,9 @@ class MoveStructure {
 
         void serialize(std::string output_dir);
         void deserialize(std::string index_dir);
-        void print_stats();
+        void verify_lfs();
         void analyze_rows();
+        void print_stats();
         bool check_alphabet(char c);
 
         std::unordered_map<uint32_t, uint32_t> jumps;
@@ -112,6 +113,7 @@ class MoveStructure {
         // Example: alphamap[A] -> 0, alphamap[C] -> 1
         std::vector<uint64_t> alphamap;
 
+        std::vector<uint64_t> all_p;
         std::vector<std::unique_ptr<sdsl::bit_vector> > occs;
         std::vector<std::unique_ptr<sdsl::rank_support_v<> > > occs_rank;
         sdsl::bit_vector bits;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -64,6 +64,7 @@ class MoveStructure {
 
         void serialize();
         void deserialize();
+        void verify_lfs();
         void print_stats();
         void analyze_rows();
         bool check_alphabet(char c);

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -13,6 +13,7 @@ class MoviOptions {
         bool no_prefetch() { return !prefetch; }
         bool is_verbose() { return verbose; }
         bool is_logs() { return logs; }
+        bool if_verify() { return verify; }
         bool is_pml() { return pml_query; }
         bool is_count() { return count_query; }
         bool is_reverse() { return reverse; }
@@ -28,6 +29,7 @@ class MoviOptions {
 
         void set_verbose(bool verbose_) { verbose = verbose_; }
         void set_logs(bool logs_) { logs = logs_; }
+        void set_verify(bool verify_) { verify = verify_; }
         void set_pml(bool pml_) { pml_query = pml_; }
         void set_count(bool count_) { count_query = count_; pml_query = false;}
         void set_reverse(bool reverse_) { reverse = reverse_; }
@@ -61,6 +63,7 @@ class MoviOptions {
             std::cerr << "reverse:\t" << reverse << "\n";
             std::cerr << "prefetch:\t" << prefetch << "\n";
             std::cerr << "strands:\t" << strands << "\n";
+            std::cerr << "verify:\t" << verify << "\n";
             std::cerr << "verbose:\t" << verbose << "\n";
             std::cerr << "logs:\t" << logs << "\n";
         }
@@ -78,6 +81,7 @@ class MoviOptions {
         bool reverse = false;
         bool prefetch = true;
         size_t strands = 16;
+        bool verify = false;
         bool verbose = false;
         bool logs = false;
 };

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -1,0 +1,83 @@
+class MoviOptions {
+    public:
+        MoviOptions() {
+            command = "";
+            ref_file = "";
+            read_file = "";
+            pml_file = "";
+            index_dir = "";
+            LF_type = "reconstruct";
+            pml_query = true;
+        }
+        bool is_split() { return split; }
+        bool no_prefetch() { return !prefetch; }
+        bool is_verbose() { return verbose; }
+        bool is_logs() { return logs; }
+        bool is_pml() { return pml_query; }
+        bool is_count() { return count_query; }
+        bool is_reverse() { return reverse; }
+        size_t get_strands() { return strands; }
+        std::string get_command() { return command; }
+        std::string get_LF_type() { return LF_type; }
+
+        std::string get_ref_file() { return ref_file; }
+        std::string get_bwt_file() { return bwt_file; }
+        std::string get_read_file() { return read_file; }
+        std::string get_pml_file() { return pml_file; }
+        std::string get_index_dir() { return index_dir; }
+
+        void set_verbose(bool verbose_) { verbose = verbose_; }
+        void set_logs(bool logs_) { logs = logs_; }
+        void set_pml(bool pml_) { pml_query = pml_; }
+        void set_count(bool count_) { count_query = count_; pml_query = false;}
+        void set_reverse(bool reverse_) { reverse = reverse_; }
+        void set_prefetch(bool prefetch_) { prefetch = prefetch_; }
+        void set_strands(size_t strands_) { strands = strands_; }
+        void set_command(std::string command_) { command = command_; }
+        bool set_LF_type(std::string type) {
+            if (type == "reconstruct" or type == "sequential" or type == "random")
+                LF_type = type;
+            else
+                return false;
+            return true;
+        }
+
+        void set_ref_file(std::string file_address) { ref_file = file_address; }
+        void set_bwt_file(std::string file_address) { bwt_file = file_address; }
+        void set_read_file(std::string file_address) { read_file = file_address; }
+        void set_pml_file(std::string file_address) { pml_file = file_address; }
+        void set_index_dir(std::string dir) { index_dir = dir; }
+
+        void print_options() {
+            std::cerr << "split:\t" << split << "\n";
+            std::cerr << "ref_file:\t" << ref_file << "\n";
+            std::cerr << "bwt_file:\t" << bwt_file << "\n";
+            std::cerr << "read_file:\t" << read_file << "\n";
+            std::cerr << "pml_file:\t" << pml_file << "\n";
+            std::cerr << "index_dir:\t" << index_dir << "\n";
+            std::cerr << "LF_type:\t" << LF_type << "\n";
+            std::cerr << "pml_query:\t" << pml_query << "\n";
+            std::cerr << "count_query:\t" << count_query << "\n";
+            std::cerr << "reverse:\t" << reverse << "\n";
+            std::cerr << "prefetch:\t" << prefetch << "\n";
+            std::cerr << "strands:\t" << strands << "\n";
+            std::cerr << "verbose:\t" << verbose << "\n";
+            std::cerr << "logs:\t" << logs << "\n";
+        }
+    private:
+        std::string command;
+        std::string ref_file;
+        std::string bwt_file;
+        std::string read_file;
+        std::string pml_file;
+        std::string index_dir;
+        std::string LF_type;
+        bool split = false;
+        bool pml_query = false;
+        bool count_query = false;
+        bool reverse = false;
+        bool prefetch = true;
+        size_t strands = 16;
+        bool verbose = false;
+        bool logs = false;
+};

--- a/src/move_row.cpp
+++ b/src/move_row.cpp
@@ -43,6 +43,12 @@ void MoveRow::set_n(uint16_t n_) {
     n = n_;
 }
 
+void MoveRow::set_threshold_status(uint16_t i, uint8_t status) {
+    const uint16_t mask_thresholds = static_cast<uint16_t>(~(((1U << 2) - 1) << i*2));
+    thresholds_status = thresholds_status & mask_thresholds;
+    thresholds_status = thresholds_status |  (status << i*2);
+}
+
 void MoveRow::set_overflow_n() {
     overflow_bits = overflow_bits & mask_overflow_n;
     overflow_bits = overflow_bits | (1 >> 10);

--- a/src/move_row.cpp
+++ b/src/move_row.cpp
@@ -8,7 +8,7 @@ MoveRow::MoveRow(uint16_t n_, uint16_t offset_, uint64_t id_) {
     this->init(n_, offset_, id_);
 }
 void MoveRow::init(uint16_t n_, uint16_t offset_, uint64_t id_) {
-    overflow_bits = std::numeric_limits<uint16_t>::max();
+    overflow_bits = std::numeric_limits<uint8_t>::max();
     this->set_n(n_);
     this->set_offset(offset_);
     this->set_id(id_);
@@ -25,14 +25,14 @@ void MoveRow::set_n(uint16_t n_) {
 }
 
 void MoveRow::set_threshold_status(uint16_t i, uint8_t status) {
-    const uint16_t mask_thresholds = static_cast<uint16_t>(~(((1U << 2) - 1) << i*2));
+    const uint8_t mask_thresholds = static_cast<uint8_t>(~(((1U << 2) - 1) << i*2));
     thresholds_status = thresholds_status & mask_thresholds;
     thresholds_status = thresholds_status |  (status << i*2);
 }
 
 void MoveRow::set_overflow_n() {
     overflow_bits = overflow_bits & mask_overflow_n;
-    overflow_bits = overflow_bits | (1 >> 10);
+    overflow_bits = overflow_bits | (1 >> 4);
 }
 
 void MoveRow::set_offset(uint16_t offset_) {
@@ -41,12 +41,12 @@ void MoveRow::set_offset(uint16_t offset_) {
 
 void MoveRow::set_overflow_offset() {
     overflow_bits = overflow_bits & mask_overflow_offset;
-    overflow_bits = overflow_bits | (1 >> 11);
+    overflow_bits = overflow_bits | (1 >> 5);
 }
 
 void MoveRow::set_overflow_thresholds() {
     overflow_bits = overflow_bits & mask_overflow_thresholds;
-    overflow_bits = overflow_bits | (1 >> 12);
+    overflow_bits = overflow_bits | (1 >> 6);
 }
 
 void MoveRow::set_id(uint64_t id_) {
@@ -57,7 +57,7 @@ void MoveRow::set_id(uint64_t id_) {
 
 void MoveRow::set_c(char c_, std::vector<uint64_t>& alphamap) {
     uint64_t c_64 = static_cast<uint64_t>(alphamap[c_]);
-    uint64_t c_16 = static_cast<uint16_t>(alphamap[c_]);
-    overflow_bits = overflow_bits & mask_c;
-    overflow_bits = overflow_bits | ((c_64) << 8);
+    uint64_t c_8 = static_cast<uint8_t>(alphamap[c_]);
+    thresholds_status = thresholds_status & mask_c;
+    thresholds_status = thresholds_status | ((c_64) << 6);
 }

--- a/src/move_row.cpp
+++ b/src/move_row.cpp
@@ -9,35 +9,16 @@ MoveRow::MoveRow(uint16_t n_, uint16_t offset_, uint64_t id_) {
 }
 void MoveRow::init(uint16_t n_, uint16_t offset_, uint64_t id_) {
     overflow_bits = std::numeric_limits<uint16_t>::max();
-    // this->set_p(p_);
-    // this->set_pp(pp_);
     this->set_n(n_);
     this->set_offset(offset_);
     this->set_id(id_);
 }
-
-/*void MoveRow::init(uint16_t n_, uint16_t offset_, uint64_t id_, char c_) {
-    overflow_bits = std::numeric_limits<uint16_t>::max();
-    // this->set_p(p_);
-    // this->set_pp(pp_);
-    this->set_n(n_);
-    this->set_offset(offset_);
-    this->set_id(id_);
-    this->set_c(c_);
-}*/
 
 std::ostream& operator<<(std::ostream& os, const MoveRow& mr)
 {
-    // os << "p:" << mr.get_p() << " n:" << mr.get_n() << " pp:" << mr.get_pp() << " offset: " << mr.get_offset() << " id:" << mr.get_id();
     os << "n:" << mr.get_n() <<  " offset: " << mr.get_offset() << " id:" << mr.get_id();
     return os;
 }
-
-/*void MoveRow::set_p(uint64_t p_) {
-    p = p_;
-    overflow_bits = overflow_bits & mask_p;
-    overflow_bits = overflow_bits | (p_ >> 32);
-}*/
 
 void MoveRow::set_n(uint16_t n_) {
     n = n_;
@@ -67,13 +48,6 @@ void MoveRow::set_overflow_thresholds() {
     overflow_bits = overflow_bits & mask_overflow_thresholds;
     overflow_bits = overflow_bits | (1 >> 12);
 }
-
-
-/* void MoveRow::set_pp(uint64_t pp_) {
-    pp = pp_;
-    overflow_bits = overflow_bits & mask_pp;
-    overflow_bits = overflow_bits | ((pp_ >> 32) << 8);
-}*/
 
 void MoveRow::set_id(uint64_t id_) {
     id = id_;

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -632,7 +632,7 @@ void MoveStructure::build(std::ifstream &bwt_file) {
         std::cerr << "rank_support_v<>(&bits)(bits.size()): " << sdsl::rank_support_v<>(&bits)(bits.size()) << "\n";
     }
     sbits = sdsl::select_support_mcl<>(&bits);
-    std::vector<uint64_t> all_p;
+    all_p.resize(r);
     for (uint64_t i = 0; i < length; i++) {
         if (i % 10000 == 0)
             std::cerr << i << "\r";
@@ -680,7 +680,7 @@ void MoveStructure::build(std::ifstream &bwt_file) {
 
             // rlbwt[r_idx].init(bwt_row, len, lf, offset, pp_id);
             rlbwt[r_idx].init(len, offset, pp_id);
-            all_p.push_back(bwt_row);
+            all_p[r_idx] = bwt_row;
             // To take care of cases where length of the run 
             // does not fit in uint16_t
             if (len >= std::numeric_limits<uint16_t>::max()) {
@@ -1609,6 +1609,50 @@ void MoveStructure::deserialize(std::string index_dir) {
     fin.read(reinterpret_cast<char*>(&first_offsets[0]), last_runs_size*sizeof(uint64_t));
     fin.close();
 }
+
+void MoveStructure::verify_lfs() {
+    uint64_t not_matched = 0;
+    for (uint64_t i = 0; i < all_p.size(); i++) {
+        std::uint64_t end_ = (i < all_p.size() - 1) ? all_p[i + 1] : length;
+        for (uint64_t j = all_p[i]; j < end_; j++) {
+            uint64_t offset_ = j - all_p[i];
+            uint64_t idx_ = i;
+            uint64_t lf = 0;
+            if (i != end_bwt_idx) {
+                lf = LF(j);
+            } else {
+                std::cerr << "end_run = " << i << " len: " << rlbwt[i].get_n () << "\n";
+            }
+            LF_move(offset_, idx_);
+            uint64_t lf_move = all_p[idx_] + offset_;
+            if (lf != lf_move) {
+                not_matched += 1;
+                std::cerr << "j\t" << j << "\n";
+                std::cerr << "idx\t" << i << "\n";
+                std::cerr << "offset\t" << j - all_p[i] << "\n";
+                std::cerr << "rlbwt[idx].get_id\t" << rlbwt[i].get_id() << "\n";
+                std::cerr << "get_offset(i)\t" << get_offset(i) << "\n";
+                for (uint64_t k = 0; k <= i; k++) {
+                    std::cerr << rlbwt[k].get_n() << " ";
+                }
+                std::cerr << "\n\n";
+
+                std::cerr << "lf\t" << lf << "\n";
+                std::cerr << "lf_move\t" << lf_move << "\n";
+                std::cerr << "idx_\t" << idx_ << "\n";
+                std::cerr << "offset_\t" << offset_ << "\n";
+                std::cerr << "all_p[idx_]\t" << all_p[idx_] << "\n";
+                std::cerr << "\n\n\n";
+            }
+        }
+    }
+    if (not_matched == 0) {
+        std::cerr << "All the LF_move operations are correct.\n";
+    } else {
+        std::cerr << "There are " << not_matched << " LF_move operations that failed to match the true lf results.\n";
+    }
+}
+
 
 void MoveStructure::analyze_rows() {
     for (int i = 0; i < first_runs.size(); i++) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -428,6 +428,7 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
         // [TODO] Not all the states where the multiple non-trivial thresholds exists are checked here
         if (rlbwt[idx].get_threshold() != value and
             rlbwt[idx].get_threshold() != 0 and
+            rlbwt[idx].get_threshold() != get_n(idx) and
             !rlbwt[i].is_overflow_thresholds()) {
             std::cerr << "idx: " << idx << " i: " << i << " value: " << value << "\n";
             std::cerr << rlbwt[idx].get_threshold() << " " << !rlbwt[i].is_overflow_thresholds() << "\n";
@@ -439,10 +440,10 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
     rlbwt[idx].set_threshold_status(i, status);
 #endif
 
-#if MODE == 2
+// #if MODE == 2
     // rlbwt_1bit_thresholds[idx] = value;
     rlbwt[idx].set_threshold(value);
-#endif
+// #endif
 }
 
 void MoveStructure::set_onebit() {
@@ -1216,7 +1217,7 @@ uint64_t MoveStructure::query_pml(MoveQuery& mq, bool random) {
                     std::cerr << "\t idx: " << idx << " offset: " << offset << "\n";
             } else {
                 std::cerr << "\t \t This should not happen!\n";
-                std::cerr << "\t \t r[pos]:" <<  R[pos_on_r] << " t[pointer]:" << c << "\n";
+                std::cerr << "\t \t pos: " << pos_on_r << " r[pos]:" <<  R[pos_on_r] << " t[pointer]:" << c << "\n";
                 std::cerr << "\t \t " << up << ", " << onebit << ", " << R[pos_on_r] << ", " << pos_on_r << "\n";
                 std::cerr << "\t \t ";
                 for (int k = 10; k > 0; --k)

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1594,6 +1594,49 @@ void MoveStructure::deserialize() {
     fin.close();
 }
 
+void MoveStructure::verify_lfs() {
+    uint64_t not_matched = 0;
+    for (uint64_t i = 0; i < all_p.size(); i++) {
+        std::uint64_t end_ = (i < all_p.size() - 1) ? all_p[i + 1] : length;
+        for (uint64_t j = all_p[i]; j < end_; j++) {
+            uint64_t offset_ = j - all_p[i];
+            uint64_t idx_ = i;
+            uint64_t lf = 0;
+            if (i != end_bwt_idx) {
+                lf = LF(j);
+            } else {
+                std::cerr << "end_run = " << i << " len: " << rlbwt[i].get_n () << "\n";
+            }
+            LF_move(offset_, idx_);
+            uint64_t lf_move = all_p[idx_] + offset_;
+            if (lf != lf_move) {
+                not_matched += 1;
+                std::cerr << "j\t" << j << "\n";
+                std::cerr << "idx\t" << i << "\n";
+                std::cerr << "offset\t" << j - all_p[i] << "\n";
+                std::cerr << "rlbwt[idx].get_id\t" << rlbwt[i].get_id() << "\n";
+                std::cerr << "get_offset(i)\t" << get_offset(i) << "\n";
+                for (uint64_t k = 0; k <= i; k++) {
+                    std::cerr << rlbwt[k].get_n() << " ";
+                }
+                std::cerr << "\n\n";
+
+                std::cerr << "lf\t" << lf << "\n";
+                std::cerr << "lf_move\t" << lf_move << "\n";
+                std::cerr << "idx_\t" << idx_ << "\n";
+                std::cerr << "offset_\t" << offset_ << "\n";
+                std::cerr << "all_p[idx_]\t" << all_p[idx_] << "\n";
+                std::cerr << "\n\n\n";
+            }
+        }
+    }
+    if (not_matched == 0) {
+        std::cerr << "All the LF_move operations are correct.\n";
+    } else {
+        std::cerr << "There are " << not_matched << " LF_move operations that failed to match the true lf results.\n";
+    }
+}
+
 void MoveStructure::analyze_rows() {
     for (int i = 0; i < first_runs.size(); i++) {
         std::cerr << i << "\t" << first_runs[i] << "\t" << last_runs[i] << "\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -355,7 +355,7 @@ uint64_t MoveStructure::get_n(uint64_t idx) {
 }
 
 uint64_t MoveStructure::get_n_ff(uint64_t idx) {
-    if (rlbwt[idx].is_overflow_n_ff()) {
+    if (rlbwt[idx].is_overflow_n()) {
         return n_overflow[rlbwt[idx].get_n_ff()];
     } else {
         return rlbwt[idx].get_n_ff();
@@ -936,12 +936,12 @@ uint64_t MoveStructure::fast_forward(uint64_t& offset, uint64_t idx, uint64_t x)
 uint64_t MoveStructure::jump_up(uint64_t idx, char c, uint64_t& scan_count) {
     if (idx == 0)
         return r;
-    char row_c = alphabet[rlbwt[idx].get_c_jj()];
+    char row_c = alphabet[rlbwt[idx].get_c()];
 
     while (idx > 0 and row_c != c) {
         scan_count += 1;
         idx -= 1;
-        row_c = alphabet[rlbwt[idx].get_c_jj()];
+        row_c = alphabet[rlbwt[idx].get_c()];
         // if (idx == 0) {
         //     break;
         // }
@@ -960,12 +960,12 @@ uint64_t MoveStructure::jump_up(uint64_t idx, char c, uint64_t& scan_count) {
 uint64_t MoveStructure::jump_down(uint64_t idx, char c, uint64_t& scan_count) {
     if (idx == r - 1)
         return r;
-    char row_c = alphabet[rlbwt[idx].get_c_jj()];
+    char row_c = alphabet[rlbwt[idx].get_c()];
 
     while (idx < r - 1 && row_c != c) {
         scan_count += 1;
         idx += 1;
-        row_c = alphabet[rlbwt[idx].get_c_jj()];
+        row_c = alphabet[rlbwt[idx].get_c()];
     }
     /* if (logs) {
         if (jumps.find(scan_count) != jumps.end())
@@ -1046,7 +1046,7 @@ uint64_t MoveStructure::backward_search(std::string& R,  int32_t& pos_on_r) {
                     }
                 }
             } else {
-                char rlbwt_char = alphabet[rlbwt[run_start].get_c_jj()];
+                char rlbwt_char = alphabet[rlbwt[run_start].get_c()];
                 uint64_t alphabet_index = alphamap_3[alphamap[rlbwt_char]][read_alphabet_index];
                 if (rlbwt[run_start].get_next_down(alphabet_index) == std::numeric_limits<uint16_t>::max()) {
                     run_start = r;
@@ -1062,7 +1062,7 @@ uint64_t MoveStructure::backward_search(std::string& R,  int32_t& pos_on_r) {
             }
         }
         if ((run_end > run_start) and (alphabet[rlbwt[run_end].get_c()] != R[pos_on_r])) {
-            char rlbwt_char = alphabet[rlbwt[run_end].get_c_jj()];
+            char rlbwt_char = alphabet[rlbwt[run_end].get_c()];
             uint64_t alphabet_index = alphamap_3[alphamap[rlbwt_char]][read_alphabet_index];
             if (rlbwt[run_end].get_next_up(alphabet_index) == std::numeric_limits<uint16_t>::max()) {
                 run_end = r;
@@ -1201,7 +1201,7 @@ uint64_t MoveStructure::query_pml(MoveQuery& mq, bool random) {
             match_len = 0;
             // scan_count = (!constant) ? std::abs((int)idx - (int)idx_before_jump) : 0;
  
-            char c = alphabet[rlbwt[idx].get_c_mm()];
+            char c = alphabet[rlbwt[idx].get_c()];
 
             if (verbose)
                 std::cerr << "\t up: " << up << " idx: " << idx << " c:" << c << "\n";
@@ -1260,7 +1260,7 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
     if (verbose)
         std::cerr << "\t \t \t jumping with thresholds ... \n";
 
-    char rlbwt_char = alphabet[rlbwt[idx].get_c_jj()];
+    char rlbwt_char = alphabet[rlbwt[idx].get_c()];
 
     if (verbose) {
         std::cerr << "\t \t \t alphabet_index: " << alphabet_index << " r_char:" << r_char << " rlbwt_char:" << rlbwt_char << "\n";
@@ -1287,8 +1287,8 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 #if MODE == 0 || MODE == 2
             idx = jump_down(saved_idx, r_char, scan_count);
 #endif
-            if (r_char != alphabet[rlbwt[idx].get_c_mm()])
-                std::cerr << "1: " << r_char << " " << alphabet[rlbwt[idx].get_c_mm()];
+            if (r_char != alphabet[rlbwt[idx].get_c()])
+                std::cerr << "1: " << r_char << " " << alphabet[rlbwt[idx].get_c()];
             return false;
         } else {
             if (verbose)
@@ -1306,8 +1306,8 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 #if MODE == 0 || MODE == 2
             idx = jump_up(saved_idx, r_char, scan_count);
 #endif
-            if (r_char != alphabet[rlbwt[idx].get_c_mm()])
-                std::cerr << "2: " << r_char << " " << alphabet[rlbwt[idx].get_c_mm()];
+            if (r_char != alphabet[rlbwt[idx].get_c()])
+                std::cerr << "2: " << r_char << " " << alphabet[rlbwt[idx].get_c()];
             return true;
         }
     }
@@ -1340,8 +1340,8 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 #if MODE == 0 || MODE == 2
         idx = jump_down(saved_idx, r_char, scan_count);
 #endif
-        if (r_char != alphabet[rlbwt[idx].get_c_mm()]) {
-            std::cerr << "3: " << r_char << " " << alphabet[rlbwt[idx].get_c_mm()] << "\n";
+        if (r_char != alphabet[rlbwt[idx].get_c()]) {
+            std::cerr << "3: " << r_char << " " << alphabet[rlbwt[idx].get_c()] << "\n";
             std::cerr << "idx: " << idx << " saved_idx: " << saved_idx << " tmp: " << tmp << "\n";
             std::cerr << "offset: " << offset << "\n";
             std::cerr << "get_thresholds(saved_idx, alphabet_index): " << get_thresholds(saved_idx, alphabet_index) << "\n";
@@ -1363,9 +1363,9 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 #if MODE == 0 || MODE == 2
         idx = jump_up(saved_idx, r_char, scan_count);
 #endif
-        if (r_char != alphabet[rlbwt[idx].get_c_mm()]) {
+        if (r_char != alphabet[rlbwt[idx].get_c()]) {
             std::cerr << "idx: " << idx << " saved_idx: " << saved_idx << "\n";
-            std::cerr << "4: " << r_char << " " << alphabet[rlbwt[idx].get_c_mm()] << "\n";
+            std::cerr << "4: " << r_char << " " << alphabet[rlbwt[idx].get_c()] << "\n";
             std::cerr << "offset: " << offset << "\n";
             std::cerr << "get_thresholds(saved_idx, alphabet_index): " << get_thresholds(saved_idx, alphabet_index) << "\n";
         }
@@ -1374,8 +1374,8 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 
     // TODO: default return?
 
-    if (r_char != alphabet[rlbwt[idx].get_c_mm()])
-        std::cerr << "5: " << r_char << " " << alphabet[rlbwt[idx].get_c_mm()];
+    if (r_char != alphabet[rlbwt[idx].get_c()])
+        std::cerr << "5: " << r_char << " " << alphabet[rlbwt[idx].get_c()];
     return false;
 }
 

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -425,11 +425,13 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
         if (rlbwt[idx].get_threshold() != value and
             rlbwt[idx].get_threshold() != 0 and
             rlbwt[idx].get_threshold() != get_n(idx) and
-            !rlbwt[i].is_overflow_thresholds()) {
-            std::cerr << "idx: " << idx << " i: " << i << " value: " << value << "\n";
-            std::cerr << rlbwt[idx].get_threshold() << " " << !rlbwt[i].is_overflow_thresholds() << "\n";
-            std::cerr << "There are more than 1 non-trivial threshold values.\n";
-            exit(0);
+            !rlbwt[idx].is_overflow_thresholds()) {
+            // std::cerr << "idx: " << idx << " i: " << i << " value: " << value << "\n";
+            // std::cerr << rlbwt[idx].get_threshold() << " " << !rlbwt[i].is_overflow_thresholds() << "\n";
+            // std::cerr << "There are more than 1 non-trivial threshold values.\n";
+            // exit(0);
+            rlbwt[i].set_overflow_thresholds();
+            return;
         }
         rlbwt[idx].set_threshold(value);
     }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -386,8 +386,17 @@ uint16_t MoveStructure::get_rlbwt_thresholds(uint64_t idx, uint16_t i) {
     }
 
 #if MODE == 0 || MODE == 1
-    if (!onebit) {
-        return rlbwt[idx].get_thresholds(i);
+    // if (!onebit) {
+    //     return rlbwt[idx].get_thresholds(i);
+    // }
+    uint8_t status = rlbwt[idx].get_threshold_status(i);
+    switch (status) {
+        case 0: return 0; break;
+        case 1: return get_n(idx); break;
+        case 3: return rlbwt[idx].get_threshold(); break;
+        default:
+            std::cerr << "Undefined status for thresholds status: " << status << "\n";
+            exit(0);
     }
 #endif
 
@@ -405,10 +414,25 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
     }
 
 #if MODE == 0 || MODE == 1
-    if (!onebit) {
-        // rlbwt_thresholds[idx][i] = value;
-        rlbwt[idx].set_thresholds(i, value);
+    // if (!onebit) {
+    //     // rlbwt_thresholds[idx][i] = value;
+    //     rlbwt[idx].set_thresholds(i, value);
+    // }
+    uint8_t status = 0;
+    if (value == 0) {
+        status = 0;
+    } else if (value == get_n(idx)) {
+        status = 3;
+    } else {
+        status = 1;
+        // [TODO] Not all the states where the multiple non-trivial thresholds exists are checked here
+        if (rlbwt[idx].get_threshold() != 0 and !rlbwt[i].is_overflow_thresholds()) {
+            std::cerr << "There are more than 1 non-trivial threshold values.\n";
+            exit(0);
+        }
+        rlbwt[idx].set_threshold(value);
     }
+    rlbwt[idx].set_threshold_status(i, status);
 #endif
 
 #if MODE == 2
@@ -747,7 +771,6 @@ void MoveStructure::build(std::ifstream &bwt_file) {
                                 << "alphamap_3[alphamap[rlbwt_c]][j] = " << alphamap_3[alphamap[rlbwt_c]][j] << "\n";
                     exit(0); // TODO: add error handling
                 }
-
                 if (alphabet_thresholds[j] >= all_p[i] + get_n(i)) {
                     // rlbwt[i].thresholds[j] = get_n(i);
                     if (rlbwt_c == END_CHARACTER) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -455,7 +455,7 @@ void MoveStructure::build_rlbwt(std::string bwt_filename) {
     std::ifstream bwt_file(bwt_filename);    
     bwt_file.clear();
     bwt_file.seekg(0,std::ios_base::end);
-    std::ios_base::streampos end_pos = bwt_file.tellg();
+    std::streampos end_pos = bwt_file.tellg();
     if (verbose)
         std::cerr << "end_pos: " << end_pos << "\n";
     std::cerr << static_cast<uint64_t>(end_pos) << "\n";
@@ -494,7 +494,7 @@ void MoveStructure::build_rlbwt(std::string bwt_filename) {
 void MoveStructure::build(std::ifstream &bwt_file) {
     bwt_file.clear();
     bwt_file.seekg(0,std::ios_base::end);
-    std::ios_base::streampos end_pos = bwt_file.tellg();
+    std::streampos end_pos = bwt_file.tellg();
     if (verbose)
         std::cerr << "end_pos: " << end_pos << "\n";
     bwt_file.seekg(0);    

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -702,10 +702,8 @@ void MoveStructure::build(std::ifstream &bwt_file) {
     std::cerr << "Max run length: " << max_len << "\n";
 
     // compute the thresholds
-    uint64_t alphabet_thresholds[4]; // TODO: change to dynamicly sized vector
     // initialize the start threshold at the last row
-    for (uint64_t j = 0; j < 4; j++)
-        alphabet_thresholds[j] = length;
+    std::vector<uint64_t> alphabet_thresholds(alphabet.size(), length);
     uint64_t thr_i = original_r - 1;
     uint64_t run_p = 0;
     if (verbose) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -414,10 +414,6 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
     }
 
 #if MODE == 0 || MODE == 1
-    // if (!onebit) {
-    //     // rlbwt_thresholds[idx][i] = value;
-    //     rlbwt[idx].set_thresholds(i, value);
-    // }
     uint8_t status = 0;
     if (value == 0) {
         status = 0;

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1583,8 +1583,42 @@ void MoveStructure::deserialize(std::string index_dir) {
     fin.read(reinterpret_cast<char*>(&first_runs[0]), last_runs_size*sizeof(uint64_t));
     first_offsets.resize(last_runs_size);
     fin.read(reinterpret_cast<char*>(&first_offsets[0]), last_runs_size*sizeof(uint64_t));
-
     fin.close();
+}
+
+void MoveStructure::analyze_rows() {
+    std::vector<uint64_t> counts(16,0);
+    for (uint64_t i = 0; i < r; i++) {
+        // std::cerr << i << " " << rlbwt[i].get_id() << " " << alphabet[rlbwt[i].get_c()] << " " << get_n(i) << " " << get_offset(i) << ":\t";
+        // for (int  j = 0; j < alphabet.size() - 1; j ++)
+        //     std::cerr << get_thresholds(i, j) << " ";
+        // std::cerr << "\n";
+        if (i%100000 == 0) std::cerr << i << "\r";
+        for (int j = 0; j < 16; j ++) {
+            if (get_n(i) >= std::pow(2,j)) {
+                counts[j] += 1;
+            }
+        }
+        if (i%10000 == 0) std::cerr << i << "\r";
+        if (((get_thresholds(i, 0) != 0 and get_thresholds(i, 0) != get_n(i)) and
+             (get_thresholds(i, 1) != 0 and get_thresholds(i, 1) != get_n(i)) and
+             (get_thresholds(i, 2) != 0 and get_thresholds(i, 2) != get_n(i)) and
+             (get_thresholds(i, 0) != get_thresholds(i, 1) or get_thresholds(i, 1) != get_thresholds(i, 2))) or
+            ((get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 1)) or
+             (get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 2)) or
+             (get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 2) != get_thresholds(i, 1)))
+            ) {
+            if (get_n(i) >= 256) {
+                std::cerr << i << " " << rlbwt[i].get_id() << " " << alphabet[rlbwt[i].get_c()] << " " << get_n(i) << " " << get_offset(i) << ":\t";
+                for (int  j = 0; j < alphabet.size() - 1; j ++)
+                    std::cerr << get_thresholds(i, j) << " ";
+                std::cerr << "\n";
+            }
+        }
+    }
+    for (int j=0; j < 16; j++) {
+        std::cerr << j << ": " << counts[j] << "\n";
+    }
 }
 
 void MoveStructure::print_stats() {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -732,17 +732,23 @@ void MoveStructure::build(std::ifstream &bwt_file) {
         for (uint64_t j = 0; j < alphabet.size(); j++) {
             if (alphabet[j] == rlbwt_c) {
                 if (thr_i >= thresholds.size()) {
-                    std::cerr << " thr_i: " << thr_i << "\n";
-                    exit(0);
+                    std::cerr << " thr_i = " << thr_i << " is out of bound:\n";
+                    std::cerr << " thresholds.size = " << thresholds.size() << "\n";
+                    exit(0); // TODO: add error handling
                 }
                 alphabet_thresholds[j] = thresholds[thr_i];
             } else {
-                if (onebit and alphamap_3[alphamap[rlbwt_c]][j] != 0)
-                    std::cerr << "error: the alphamap_3 is not working for the one-bit alphabet - " 
-                                << alphamap_3[alphamap[rlbwt_c]][j] << "!\n";
-                if (alphamap_3[alphamap[rlbwt_c]][j] == 3)
-                    std::cerr << "error: alphamap_3 is not working in general - " 
-                                << alphamap_3[alphamap[rlbwt_c]][j] << "!\n";
+                if (onebit and alphamap_3[alphamap[rlbwt_c]][j] != 0) {
+                    std::cerr << "the alphamap_3 is not working for the one-bit alphabet:\n"
+                                << "alphamap_3[alphamap[rlbwt_c]][j] = " << alphamap_3[alphamap[rlbwt_c]][j] << "\n";
+                    exit(0); // TODO: add error handling
+                }
+                if (alphamap_3[alphamap[rlbwt_c]][j] >= alphabet.size() - 1) {
+                    std::cerr << "alphamap_3 is not working in general:\n"
+                                << "alphabet.size() - 1 = " << alphabet.size() - 1 << "\n"
+                                << "alphamap_3[alphamap[rlbwt_c]][j] = " << alphamap_3[alphamap[rlbwt_c]][j] << "\n";
+                    exit(0); // TODO: add error handling
+                }
 
                 if (alphabet_thresholds[j] >= all_p[i] + get_n(i)) {
                     // rlbwt[i].thresholds[j] = get_n(i);
@@ -773,13 +779,14 @@ void MoveStructure::build(std::ifstream &bwt_file) {
                     set_rlbwt_thresholds(i, alphamap_3[alphamap[rlbwt_c]][j], alphabet_thresholds[j] - all_p[i]);
                     current_thresholds[alphamap_3[alphamap[rlbwt_c]][j]] = alphabet_thresholds[j] - all_p[i];
                 }
-
-                if (verbose and i >= rlbwt.size() - 10)
+                // printing the values for last 10 runs to debug
+                if (verbose and i >= rlbwt.size() - 10) {
                     std::cerr << "\t j: \t" << j << " "
                         << "alphabet[j]: " << alphabet[j] << "  "
                         << "alphamap_3[alphamap[rlbwt_c]][j]: " << alphamap_3[alphamap[rlbwt_c]][j] << " "
                         << "alphabet_thresholds[j]: " << alphabet_thresholds[j] << " "
                         << "rlbwt[i].thresholds[j]:" << get_rlbwt_thresholds(i, alphamap_3[alphamap[rlbwt_c]][j]) << "\n";
+                }
             }
         }
 
@@ -909,11 +916,9 @@ uint64_t MoveStructure::jump_up(uint64_t idx, char c, uint64_t& scan_count) {
         scan_count += 1;
         idx -= 1;
         row_c = alphabet[rlbwt[idx].get_c_jj()];
-        if (idx == 0) {
-            // std::cerr << "idx: " << idx << "\n";
-            // std::cerr << "row_c: " << row_c << " c: " << c << "\n";
-            break;
-        }
+        // if (idx == 0) {
+        //     break;
+        // }
     }
     /* if (logs) {
         if (jumps.find(scan_count) != jumps.end())

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -426,7 +426,11 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
     } else {
         status = 1;
         // [TODO] Not all the states where the multiple non-trivial thresholds exists are checked here
-        if (rlbwt[idx].get_threshold() != 0 and !rlbwt[i].is_overflow_thresholds()) {
+        if (rlbwt[idx].get_threshold() != value and
+            rlbwt[idx].get_threshold() != 0 and
+            !rlbwt[i].is_overflow_thresholds()) {
+            std::cerr << "idx: " << idx << " i: " << i << " value: " << value << "\n";
+            std::cerr << rlbwt[idx].get_threshold() << " " << !rlbwt[i].is_overflow_thresholds() << "\n";
             std::cerr << "There are more than 1 non-trivial threshold values.\n";
             exit(0);
         }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1615,37 +1615,71 @@ void MoveStructure::deserialize(std::string index_dir) {
 }
 
 void MoveStructure::analyze_rows() {
-    std::vector<uint64_t> counts(16,0);
+    for (int i = 0; i < first_runs.size(); i++) {
+        std::cerr << i << "\t" << first_runs[i] << "\t" << last_runs[i] << "\n";
+    }
+    std::vector<uint64_t> counts_length(16,0);
+    std::vector<uint64_t> counts_offset(16,0);
+    std::vector<uint64_t> counts_threshold0(16,0);
+    std::vector<uint64_t> counts_threshold1(16,0);
+    std::vector<uint64_t> counts_threshold2(16,0);
+    uint64_t counter = 0;
     for (uint64_t i = 0; i < r; i++) {
-        // std::cerr << i << " " << rlbwt[i].get_id() << " " << alphabet[rlbwt[i].get_c()] << " " << get_n(i) << " " << get_offset(i) << ":\t";
-        // for (int  j = 0; j < alphabet.size() - 1; j ++)
-        //     std::cerr << get_thresholds(i, j) << " ";
-        // std::cerr << "\n";
+	 counter += 1;
         if (i%100000 == 0) std::cerr << i << "\r";
         for (int j = 0; j < 16; j ++) {
-            if (get_n(i) >= std::pow(2,j)) {
-                counts[j] += 1;
+            if (get_n(i) >= std::pow(2,j + 1)) {
+                counts_length[j] += 1;
+            }
+            if (get_offset(i) >= std::pow(2,j + 1)) {
+                counts_offset[j] += 1;
+            }
+            if (get_thresholds(i, 0) >= std::pow(2,j + 1)) {
+                counts_threshold0[j] += 1;
+            }
+            if (get_thresholds(i, 1) >= std::pow(2,j + 1)) {
+                counts_threshold1[j] += 1;
+            }
+            if (get_thresholds(i, 2) >= std::pow(2,j + 1)) {
+                counts_threshold2[j] += 1;
             }
         }
-        if (i%10000 == 0) std::cerr << i << "\r";
-        if (((get_thresholds(i, 0) != 0 and get_thresholds(i, 0) != get_n(i)) and
-             (get_thresholds(i, 1) != 0 and get_thresholds(i, 1) != get_n(i)) and
-             (get_thresholds(i, 2) != 0 and get_thresholds(i, 2) != get_n(i)) and
-             (get_thresholds(i, 0) != get_thresholds(i, 1) or get_thresholds(i, 1) != get_thresholds(i, 2))) or
-            ((get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 1)) or
-             (get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 2)) or
-             (get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 2) != get_thresholds(i, 1)))
-            ) {
-            if (get_n(i) >= 256) {
-                std::cerr << i << " " << rlbwt[i].get_id() << " " << alphabet[rlbwt[i].get_c()] << " " << get_n(i) << " " << get_offset(i) << ":\t";
-                for (int  j = 0; j < alphabet.size() - 1; j ++)
-                    std::cerr << get_thresholds(i, j) << " ";
-                std::cerr << "\n";
-            }
-        }
+        // if (((get_thresholds(i, 0) != 0 and get_thresholds(i, 0) != get_n(i)) and
+        //      (get_thresholds(i, 1) != 0 and get_thresholds(i, 1) != get_n(i)) and
+        //      (get_thresholds(i, 2) != 0 and get_thresholds(i, 2) != get_n(i)) and
+        //      (get_thresholds(i, 0) != get_thresholds(i, 1) or get_thresholds(i, 1) != get_thresholds(i, 2))) or
+        //     ((get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 1)) or
+        //      (get_thresholds(i,0) != 0 and get_thresholds(i,0) != get_n(i) and get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i, 0) != get_thresholds(i, 2)) or
+        //      (get_thresholds(i,2) != 0 and get_thresholds(i,2) != get_n(i) and get_thresholds(i,1) != 0 and get_thresholds(i,1) != get_n(i) and get_thresholds(i, 2) != get_thresholds(i, 1)))
+        //     ) {
+        //     if (get_n(i) >= 256) {
+        //         std::cerr << i << " " << rlbwt[i].get_id() << " " << alphabet[rlbwt[i].get_c()] << " " << get_n(i) << " " << get_offset(i) << ":\t";
+        //         for (int  j = 0; j < alphabet.size() - 1; j ++)
+        //             std::cerr << get_thresholds(i, j) << " ";
+        //         std::cerr << "\n";
+        //     }
+        // }
     }
+    std::cerr << "counter: " << counter << "\n";
+    std::cerr << "\ncounts_length:\n";
     for (int j=0; j < 16; j++) {
-        std::cerr << j << ": " << counts[j] << "\n";
+        std::cerr << j + 1 << "\t" << counts_length[j] << "\n";
+    }
+    std::cerr << "\ncounts_offset:\n";
+    for (int j=0; j < 16; j++) {
+        std::cerr << j + 1 << "\t" << counts_offset[j] << "\n";
+    }
+    std::cerr << "\ncounts_threshold0:\n";
+    for (int j=0; j < 16; j++) {
+        std::cerr << j << ": " << counts_threshold0[j] << "\n";
+    }
+    std::cerr << "\ncounts_threshold1:\n";
+    for (int j=0; j < 16; j++) {
+        std::cerr << j << ": " << counts_threshold1[j] << "\n";
+    }
+    std::cerr << "\ncounts_threshold2:\n";
+    for (int j=0; j < 16; j++) {
+        std::cerr << j << ": " << counts_threshold2[j] << "\n";
     }
 }
 

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -392,8 +392,8 @@ uint16_t MoveStructure::get_rlbwt_thresholds(uint64_t idx, uint16_t i) {
     uint8_t status = rlbwt[idx].get_threshold_status(i);
     switch (status) {
         case 0: return 0; break;
-        case 1: return get_n(idx); break;
-        case 3: return rlbwt[idx].get_threshold(); break;
+        case 1: return rlbwt[idx].get_threshold(); break;
+        case 3: return get_n(idx); break;
         default:
             std::cerr << "Undefined status for thresholds status: " << status << "\n";
             exit(0);
@@ -440,10 +440,10 @@ void MoveStructure::set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t valu
     rlbwt[idx].set_threshold_status(i, status);
 #endif
 
-// #if MODE == 2
+#if MODE == 2
     // rlbwt_1bit_thresholds[idx] = value;
     rlbwt[idx].set_threshold(value);
-// #endif
+#endif
 }
 
 void MoveStructure::set_onebit() {

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -312,7 +312,6 @@ int main(int argc, char** argv) {
         MoveStructure mv_(movi_options.get_ref_file(), false, movi_options.is_verbose(), movi_options.is_logs(), false, MODE == 1);
         std::cerr << "The move structure is successfully stored at " << movi_options.get_index_dir() << "\n";
         mv_.serialize(movi_options.get_index_dir());
-        std::cerr << "The move structure is read from the file successfully.\n";
     } else if (command == "query") {
         MoveStructure mv_(movi_options.is_verbose(), movi_options.is_logs());
         auto begin = std::chrono::system_clock::now();

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -54,7 +54,8 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
 
     auto buildOptions = options.add_options("build")
         ("i,index", "Index directory", cxxopts::value<std::string>())
-        ("f,fasta", "Reference file", cxxopts::value<std::string>());
+        ("f,fasta", "Reference file", cxxopts::value<std::string>())
+        ("verify", "Verify if all the LF_move operations are correct");
 
     auto queryOptions = options.add_options("query")
         ("pml", "Compute the pseudo-matching lengths (PMLs)")
@@ -106,6 +107,9 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
                 if (result.count("index") == 1 and result.count("fasta") == 1) {
                     movi_options.set_index_dir(result["index"].as<std::string>());
                     movi_options.set_ref_file(result["fasta"].as<std::string>());
+                    if (result.count("verify")) {
+                        movi_options.set_verify(true);
+                    }
                 } else {
                     const std::string message = "Please include one index directory and one fasta file.";
                     cxxopts::throw_or_mimic<cxxopts::exceptions::invalid_option_format>(message);
@@ -310,8 +314,12 @@ int main(int argc, char** argv) {
     std::string command = movi_options.get_command();
     if (command == "build") {
         MoveStructure mv_(movi_options.get_ref_file(), false, movi_options.is_verbose(), movi_options.is_logs(), false, MODE == 1);
-        std::cerr << "The move structure is successfully stored at " << movi_options.get_index_dir() << "\n";
+        if (movi_options.if_verify()) {
+            std::cerr << "Verifying the LF_move results...\n";
+            mv_.verify_lfs();
+        }
         mv_.serialize(movi_options.get_index_dir());
+        std::cerr << "The move structure is successfully stored at " << movi_options.get_index_dir() << "\n";
     } else if (command == "query") {
         MoveStructure mv_(movi_options.is_verbose(), movi_options.is_logs());
         auto begin = std::chrono::system_clock::now();

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -84,7 +84,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         auto result = options.parse(argc, argv);
 
         if (result.count("help")) {
-            std::cout << options.help() << std::endl;
+            std::cerr << options.help() << std::endl;
             return 0;
         }
 
@@ -176,7 +176,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         }
     } catch (const cxxopts::exceptions::exception& e) {
         std::cerr << "Error parsing command line options: " << e.what() << "\n";
-        std::cout << options.help() << "\n";
+        std::cerr << options.help() << "\n";
         return false;
     }
     return true;
@@ -319,12 +319,12 @@ int main(int argc, char** argv) {
         mv_.deserialize(movi_options.get_index_dir());
         auto end = std::chrono::system_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
-        std::printf("Time measured for loading the index: %.3f seconds.\n", elapsed.count() * 1e-9);
+        fprintf(stderr, "Time measured for loading the index: %.3f seconds.\n", elapsed.count() * 1e-9);
         begin = std::chrono::system_clock::now();
         query(mv_, movi_options);
         end = std::chrono::system_clock::now();
         elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
-        std::printf("Time measured for processing the reads: %.3f seconds.\n", elapsed.count() * 1e-9);
+        fprintf(stderr, "Time measured for processing the reads: %.3f seconds.\n", elapsed.count() * 1e-9);
     } else if (command == "view") {
         view(movi_options);
     } else if (command == "rlbwt") {

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -345,5 +345,6 @@ int main(int argc, char** argv) {
         MoveStructure mv_(movi_options.is_verbose(), movi_options.is_logs());
         mv_.deserialize(movi_options.get_index_dir());
         mv_.print_stats();
+        // mv_.analyze_rows();
     }
 }

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -336,6 +336,10 @@ int main(int argc, char** argv) {
     std::string command = movi_options.get_command();
     if (command == "build") {
         MoveStructure mv_(&movi_options, false, false, MODE == 1);
+        if (movi_options.if_verify()) {
+            std::cerr << "Verifying the LF_move results...\n";
+            mv_.verify_lfs();
+        }
         mv_.serialize();
         std::cerr << "The move structure is successfully stored at " << movi_options.get_index_dir() << "\n";
     } else if (command == "query") {

--- a/src/prepare_ref.cpp
+++ b/src/prepare_ref.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <zlib.h>
+#include <cstdint>
 
 #include "kseq.h"
 

--- a/src/prepare_ref.cpp
+++ b/src/prepare_ref.cpp
@@ -8,7 +8,7 @@
 // STEP 1: declare the type of file handler and the read() function
 KSEQ_INIT(gzFile, gzread)
 
-void read_fasta(const char* file_name,std::ofstream& clean_fasta) {
+void read_fasta(const char* file_name, std::ofstream& clean_fasta) {
     gzFile fp;
     kseq_t *seq;
     int l;

--- a/src/read_processor.cpp
+++ b/src/read_processor.cpp
@@ -97,7 +97,7 @@ void ReadProcessor::process_char(Strand& process, MoveStructure& mv) {
         uint64_t idx_before_jump = process.idx;
         bool up = mv.jump_thresholds(process.idx, process.offset, R[process.pos_on_r], process.scan_count);
         process.match_len = 0;
-        char c = mv.alphabet[mv.rlbwt[process.idx].get_c_mm()];
+        char c = mv.alphabet[mv.rlbwt[process.idx].get_c()];
         // sanity check
         if (c == R[process.pos_on_r]) {
             // Observing a match after the jump
@@ -361,7 +361,7 @@ bool ReadProcessor::backward_search(Strand& process, MoveStructure& mv, uint64_t
                 }
             }
         } else {
-            char rlbwt_char = mv.alphabet[mv.rlbwt[process.range.run_start].get_c_jj()];
+            char rlbwt_char = mv.alphabet[mv.rlbwt[process.range.run_start].get_c()];
             uint64_t alphabet_index = alphamap_3_[mv.alphamap[rlbwt_char]][read_alphabet_index];
             if (mv.rlbwt[process.range.run_start].get_next_down(alphabet_index) == std::numeric_limits<uint16_t>::max()) {
                 process.range.run_start = mv.r;
@@ -377,7 +377,7 @@ bool ReadProcessor::backward_search(Strand& process, MoveStructure& mv, uint64_t
         }
     }
     if ((process.range.run_end > process.range.run_start) and (mv.alphabet[mv.rlbwt[process.range.run_end].get_c()] != R[process.pos_on_r])) {
-        char rlbwt_char = mv.alphabet[mv.rlbwt[process.range.run_end].get_c_jj()];
+        char rlbwt_char = mv.alphabet[mv.rlbwt[process.range.run_end].get_c()];
         uint64_t alphabet_index = alphamap_3_[mv.alphamap[rlbwt_char]][read_alphabet_index];
         if (mv.rlbwt[process.range.run_end].get_next_up(alphabet_index) == std::numeric_limits<uint16_t>::max()) {
             process.range.run_end = mv.r;


### PR DESCRIPTION
This branch includes the changes for optimizing the size of the rows in the move structure table.

The size of the new rows are 12 bytes instead of 16 bytes (which was the case before). There is also a reordering of the fields which results in the smaller final row sizes.

A method for verifying all the LF operations is also implemented which guarantees that consecutive LF mapping starting from each row will circle back to that row after exactly n steps where n is equal to the length of the original text.