### PR TITLE
Add a mode for building the index by sampling the id column

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ add_executable(movi-compact-thresholds src/movi.cpp src/move_structure.cpp src/m
 target_link_libraries(movi-compact-thresholds sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact-thresholds PUBLIC -O2 -DMODE=6)
 
+add_executable(movi-tally-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+target_link_libraries(movi-tally-thresholds sdsl ZLIB::ZLIB)
+target_compile_options(movi-tally-thresholds PUBLIC -O2 -DMODE=7)
+
 add_executable(prepare_ref src/prepare_ref.cpp)
 target_link_libraries(prepare_ref ZLIB::ZLIB)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ add_executable(movi-compact src/movi.cpp src/move_structure.cpp src/move_row.cpp
 target_link_libraries(movi-compact sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact PUBLIC -O2 -DMODE=3)
 
+add_executable(movi-tally src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+target_link_libraries(movi-tally sdsl ZLIB::ZLIB)
+target_compile_options(movi-tally PUBLIC -O2 -DMODE=5)
+
 add_executable(movi-split src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
 target_link_libraries(movi-split sdsl ZLIB::ZLIB)
 target_compile_options(movi-split PUBLIC -O2 -DMODE=4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ add_executable(movi-compact src/movi.cpp src/move_structure.cpp src/move_row.cpp
 target_link_libraries(movi-compact sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact PUBLIC -O2 -DMODE=3)
 
-add_executable(movi-tally src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
+add_executable(movi-tally src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-tally sdsl ZLIB::ZLIB)
 target_compile_options(movi-tally PUBLIC -O2 -DMODE=5)
 
-add_executable(movi-split src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
+add_executable(movi-split src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-split sdsl ZLIB::ZLIB)
 target_compile_options(movi-split PUBLIC -O2 -DMODE=4)
 
@@ -74,7 +74,7 @@ add_executable(movi-compact-thresholds src/movi.cpp src/move_structure.cpp src/m
 target_link_libraries(movi-compact-thresholds sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact-thresholds PUBLIC -O2 -DMODE=6)
 
-add_executable(movi-tally-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
+add_executable(movi-tally-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-tally-thresholds sdsl ZLIB::ZLIB)
 target_compile_options(movi-tally-thresholds PUBLIC -O2 -DMODE=7)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,31 +50,31 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++14")
 # add_compile_options(-fsanitize-recover=unsigned-integer-overflow)
 # add_link_options(-fsanitize-recover=unsigned-integer-overflow)
 
-add_executable(movi-default src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-default src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-default sdsl ZLIB::ZLIB)
 target_compile_options(movi-default PUBLIC -O2 -DMODE=0)
 
-add_executable(movi-constant src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-constant src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-constant sdsl ZLIB::ZLIB)
 target_compile_options(movi-constant PUBLIC -O2 -DMODE=1)
 
-add_executable(movi-compact src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-compact src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-compact sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact PUBLIC -O2 -DMODE=3)
 
-add_executable(movi-tally src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-tally src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
 target_link_libraries(movi-tally sdsl ZLIB::ZLIB)
 target_compile_options(movi-tally PUBLIC -O2 -DMODE=5)
 
-add_executable(movi-split src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-split src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
 target_link_libraries(movi-split sdsl ZLIB::ZLIB)
 target_compile_options(movi-split PUBLIC -O2 -DMODE=4)
 
-add_executable(movi-compact-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-compact-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/utils.cpp src/sequitur.cpp)
 target_link_libraries(movi-compact-thresholds sdsl ZLIB::ZLIB)
 target_compile_options(movi-compact-thresholds PUBLIC -O2 -DMODE=6)
 
-add_executable(movi-tally-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp)
+add_executable(movi-tally-thresholds src/movi.cpp src/move_structure.cpp src/move_row.cpp src/read_processor.cpp src/sequitur.cpp)
 target_link_libraries(movi-tally-thresholds sdsl ZLIB::ZLIB)
 target_compile_options(movi-tally-thresholds PUBLIC -O2 -DMODE=7)
 
@@ -82,7 +82,7 @@ add_executable(prepare_ref src/prepare_ref.cpp)
 target_link_libraries(prepare_ref ZLIB::ZLIB)
 
 if (BUILD_TEST STREQUAL "1")
-  add_executable(test_bidirectional src/test_bidirectional.cpp src/move_structure.cpp src/move_row.cpp)
+  add_executable(test_bidirectional src/test_bidirectional.cpp src/move_structure.cpp src/move_row.cpp src/utils.cpp src/sequitur.cpp)
   target_link_libraries(test_bidirectional sdsl ZLIB::ZLIB)
   target_compile_options(test_bidirectional PUBLIC -O2 -DMODE=3)
 endif ()

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -128,6 +128,7 @@ class __attribute__((packed)) MoveRow {
 #endif
 #if MODE == 3 or MODE == 6
         MoveRow () {n = 0; id = 0; offset = 0;}
+        void print_all();
 #endif
 #if MODE == 0 or MODE == 1 or MODE == 3 or MODE == 4 or MODE == 6
         MoveRow(uint16_t n_, uint16_t offset_, uint64_t id_);
@@ -290,6 +291,12 @@ inline char MoveRow::get_c() const{
 #endif
 
 #if MODE == 3 or MODE == 6
+inline void MoveRow::print_all() {
+    std::cerr << "id:\t" << std::bitset<16>(id) <<
+                 "\nn:\t" << std::bitset<16>(n) <<
+                 "\noffset:\t" << std::bitset<16>(offset) << "\n";
+}
+
 inline uint16_t extract_value(uint16_t source, uint16_t mask, uint16_t shift) {
     uint16_t res = (source & (~mask)) >> shift;
     return res;

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -296,9 +296,12 @@ inline uint16_t extract_value(uint16_t source, uint16_t mask, uint16_t shift) {
 }
 
 inline uint64_t MoveRow::get_id() const{
-    if (n >= (1U << SHIFT_ID1) ) {
-        uint64_t res = static_cast<uint64_t>(extract_value(n, mask_id1, SHIFT_ID1));
-        res = res << 16;
+    if (n >= (1U << SHIFT_ID1) or offset >= (1U << SHIFT_ID2) ) {
+        uint64_t res = 0;
+        if (n >= (1U << SHIFT_ID1) ) {
+            res = static_cast<uint64_t>(extract_value(n, mask_id1, SHIFT_ID1));
+            res = res << 16;
+        }
         if (offset >= (1U << SHIFT_ID2) ) {
             uint64_t res2 = static_cast<uint64_t>(extract_value(offset, mask_id2, SHIFT_ID2));
             res2 = res2 << SHIFT_ID1_RES;

--- a/include/move_row.hpp
+++ b/include/move_row.hpp
@@ -6,14 +6,14 @@
 #include <bitset>
 
 #if MODE == 0 or MODE == 1 or MODE == 4
-const uint8_t mask_thresholds1 = static_cast<uint8_t>(~(((1U << 2) - 1) << 0)); // 00000011
-const uint8_t mask_thresholds2 = static_cast<uint8_t>(~(((1U << 2) - 1) << 2)); // 00001100
-const uint8_t mask_thresholds3 = static_cast<uint8_t>(~(((1U << 2) - 1) << 4)); // 00110000
-const uint8_t mask_c = static_cast<uint8_t>(~(((1U << 2) - 1) << 6));           // 11000000
-const uint8_t mask_id =  static_cast<uint8_t>(~(((1U << 4) - 1) << 0));                  // 00001111
-const uint8_t mask_overflow_n = static_cast<uint8_t>(~(((1U << 1) - 1) << 4));           // 00010000
-const uint8_t mask_overflow_offset = static_cast<uint8_t>(~(((1U << 1) - 1) << 5));      // 00100000
-const uint8_t mask_overflow_thresholds = static_cast<uint8_t>(~(((1U << 1) - 1) << 6));  // 01000000
+const uint8_t mask_thresholds1 = static_cast<uint8_t>(~(((1U << 2) - 1) << 0));         // 00000011
+const uint8_t mask_thresholds2 = static_cast<uint8_t>(~(((1U << 2) - 1) << 2));         // 00001100
+const uint8_t mask_thresholds3 = static_cast<uint8_t>(~(((1U << 2) - 1) << 4));         // 00110000
+const uint8_t mask_c = static_cast<uint8_t>(~(((1U << 2) - 1) << 6));                   // 11000000
+const uint8_t mask_id =  static_cast<uint8_t>(~(((1U << 4) - 1) << 0));                 // 00001111
+const uint8_t mask_overflow_n = static_cast<uint8_t>(~(((1U << 1) - 1) << 4));          // 00010000
+const uint8_t mask_overflow_offset = static_cast<uint8_t>(~(((1U << 1) - 1) << 5));     // 00100000
+const uint8_t mask_overflow_thresholds = static_cast<uint8_t>(~(((1U << 1) - 1) << 6)); // 01000000
 #define MAX_RUN_LENGTH 65535 // 2^16 - 1
 #endif
 

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -168,6 +168,7 @@ class MoveStructure {
 
         void verify_lfs();
         void print_stats();
+        void print_ids();
         void analyze_rows();
         bool check_alphabet(char& c);
 

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -23,6 +23,7 @@
 
 #define END_CHARACTER 0
 #define THRBYTES 5 
+#define TALLY_CHECKPOINTS 20
 
 struct MoveInterval {
     MoveInterval() {}
@@ -242,6 +243,9 @@ class MoveStructure {
 
         // The move structure rows
         std::vector<MoveRow> rlbwt;
+#if MODE == 5
+        std::vector<std::vector<MoveTally>> tally_ids;
+#endif
 
         // auxilary datastructures for the length, offset and thresholds overflow
         std::vector<uint64_t> n_overflow;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -221,7 +221,7 @@ class MoveStructure {
         uint32_t tally_checkpoints;
         std::vector<std::vector<MoveTally>> tally_ids;
 #endif
-        std::vector<std::vector<uint64_t>> id_blocks;
+        std::vector<std::vector<uint32_t>> id_blocks;
 
         // auxilary datastructures for the length, offset and thresholds overflow
         std::vector<uint64_t> n_overflow;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -23,7 +23,6 @@
 
 #define END_CHARACTER 0
 #define THRBYTES 5 
-#define TALLY_CHECKPOINTS 20
 
 struct MoveInterval {
     MoveInterval() {}
@@ -245,6 +244,7 @@ class MoveStructure {
         // The move structure rows
         std::vector<MoveRow> rlbwt;
 #if MODE == 5 or MODE == 7
+        uint32_t tally_checkpoints;
         std::vector<std::vector<MoveTally>> tally_ids;
 #endif
         std::vector<std::vector<uint64_t>> id_blocks;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -141,7 +141,8 @@ class MoveStructure {
         std::string reconstruct_lf();
 
         uint64_t LF(uint64_t row_number);
-        uint16_t LF_move(uint64_t& pointer, uint64_t& i);
+        // The 3rd argument of LF_move is used in the latency_hiding_tally mode
+        uint16_t LF_move(uint64_t& pointer, uint64_t& i, uint64_t id = std::numeric_limits<uint64_t>::max());
         uint64_t fast_forward(uint64_t& offset, uint64_t index, uint64_t x);
 
         uint64_t compute_threshold(uint64_t r_idx, uint64_t pointer, char lookup_char);

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -20,6 +20,7 @@
 #include "movi_options.hpp"
 #include "move_row.hpp"
 #include "move_query.hpp"
+#include "sequitur.hpp"
 
 #define END_CHARACTER 0
 #define THRBYTES 5 
@@ -102,33 +103,6 @@ struct MoveBiInterval {
         output << mi_bi.match_len << ": " << mi_bi.fw_interval << "\t" << mi_bi.rc_interval;
         return output;
     }
-};
-
-struct KmerStatistics {
-    uint64_t total_kmers() {
-        return positive_kmers + look_ahead_skipped + initialize_skipped + backward_search_failed + backward_search_empty;
-    }
-    void print() {
-        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
-        std::cout << "total_kmers:\t\t" <<  total_kmers() << "\n";
-        std::cout << "positive_skipped:\t" << positive_skipped << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(positive_skipped) / static_cast<double>(total_kmers()) << "%\n";
-        std::cout << "backward_search_failed:\t" << backward_search_failed << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(backward_search_failed) / static_cast<double>(total_kmers()) << "%\n";
-        std::cout << "look_ahead_skipped:\t" << look_ahead_skipped << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(look_ahead_skipped) / static_cast<double>(total_kmers()) << "%\n";
-        std::cout << "initialize_skipped:\t" << initialize_skipped << "\t"
-                    << std::setprecision(2) << 100 * static_cast<double>(initialize_skipped) / static_cast<double>(total_kmers()) << "%\n";
-        std::cout << "backward_search_empty:\t" << backward_search_empty << "\t"
-                    << std::setprecision(2) << 100 * static_cast<double>(backward_search_empty) / static_cast<double>(total_kmers()) << "%\n";
-        std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
-    }
-    uint64_t positive_kmers = 0;
-    uint64_t positive_skipped = 0;
-    uint64_t look_ahead_skipped = 0;
-    uint64_t initialize_skipped = 0;
-    uint64_t backward_search_failed = 0;
-    uint64_t backward_search_empty = 0;
 };
 
 class MoveStructure {

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -204,7 +204,7 @@ class MoveStructure {
         uint64_t get_n(uint64_t idx);
         uint64_t get_offset(uint64_t idx);
         uint64_t get_id(uint64_t idx);
-#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6
+#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6 or MODE == 7
         void compute_thresholds();
         bool jump_thresholds(uint64_t& idx, uint64_t offset, char r_char, uint64_t& scan_count);
         uint64_t get_thresholds(uint64_t idx, uint32_t alphabet_index);
@@ -244,7 +244,7 @@ class MoveStructure {
 
         // The move structure rows
         std::vector<MoveRow> rlbwt;
-#if MODE == 5
+#if MODE == 5 or MODE == 7
         std::vector<std::vector<MoveTally>> tally_ids;
 #endif
         std::vector<std::vector<uint64_t>> id_blocks;

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -32,6 +32,7 @@ class MoviOptions {
         size_t get_strands() { return strands; }
         uint32_t get_k () { return k; }
         uint32_t get_ftab_k () { return ftab_k; }
+        uint32_t get_tally_checkpoints () { return tally_checkpoints; }
         std::string get_command() { return command; }
         std::string get_LF_type() { return LF_type; }
 
@@ -55,6 +56,7 @@ class MoviOptions {
         void set_kmer_count(bool kmer_count_) { kmer_count = kmer_count_; }
         void set_k(uint32_t k_) { k = k_; }
         void set_ftab_k(uint32_t ftab_k_) { ftab_k = ftab_k_; }
+        void set_tally_checkpoints(uint32_t tally_checkpoints_) { tally_checkpoints = tally_checkpoints_; }
         void set_multi_ftab(bool multi_ftab_) { multi_ftab = multi_ftab_; }
         void set_reverse(bool reverse_) { reverse = reverse_; }
         bool set_ignore_illegal_chars(int ilc_) {
@@ -95,6 +97,7 @@ class MoviOptions {
             std::cerr << "zml_query:\t" << zml_query << "\n";
             std::cerr << "count_query:\t" << count_query << "\n";
             std::cerr << "ftab_k:\t" << ftab_k << "\n";
+            std::cerr << "tally_checkpoints:\t" << tally_checkpoints << "\n";
             std::cerr << "reverse:\t" << reverse << "\n";
             std::cerr << "prefetch:\t" << prefetch << "\n";
             std::cerr << "strands:\t" << strands << "\n";
@@ -126,6 +129,7 @@ class MoviOptions {
         size_t strands = 16;
         uint32_t k = 31;
         uint32_t ftab_k = 0;
+        uint32_t tally_checkpoints = 20;
         bool multi_ftab = false;
         bool verify = false;
         bool write_stdout = false;

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -16,6 +16,7 @@ class MoviOptions {
         bool is_split() { return split; }
         bool is_thresholds() { return thresholds; }
         bool no_prefetch() { return !prefetch; }
+        bool is_output_ids() { return output_ids; }
         bool is_stdout() { return write_stdout; }
         bool is_verbose() { return verbose; }
         bool is_logs() { return logs; }
@@ -44,6 +45,7 @@ class MoviOptions {
 
         void set_preprocessed(bool preprocessed_) { preprocessed = preprocessed_; }
         void set_thresholds(bool thresholds_) { thresholds = thresholds_; }
+        void set_output_ids(bool output_ids_) { output_ids = output_ids_; }
         void set_stdout(bool write_stdout_) { write_stdout = write_stdout_; }
         void set_verbose(bool verbose_) { verbose = verbose_; }
         void set_logs(bool logs_) { logs = logs_; }
@@ -102,6 +104,7 @@ class MoviOptions {
             std::cerr << "prefetch:\t" << prefetch << "\n";
             std::cerr << "strands:\t" << strands << "\n";
             std::cerr << "verify:\t" << verify << "\n";
+            std::cerr << "output_ids:\t" << output_ids << "\n";
             std::cerr << "stdout:\t" << write_stdout << "\n";
             std::cerr << "debug:\t" << debug << "\n";
             std::cerr << "verbose:\t" << verbose << "\n";
@@ -132,6 +135,8 @@ class MoviOptions {
         uint32_t tally_checkpoints = 20;
         bool multi_ftab = false;
         bool verify = false;
+
+        bool output_ids = false;
         bool write_stdout = false;
         bool debug = false;
         bool verbose = false;

--- a/include/read_processor.hpp
+++ b/include/read_processor.hpp
@@ -18,6 +18,18 @@ struct Strand {
     MoveInterval range;
     MoveInterval range_prev;
 
+#if MODE == 5 or MODE == 7
+    bool tally_state = false;
+    uint64_t tally_b;
+    uint64_t rows_until_tally;
+    uint64_t next_check_point;
+    uint64_t last_id;
+    uint64_t run_id;
+    bool id_found;
+    uint8_t char_index;
+    uint16_t tally_offset;
+#endif
+
     bool kmer_extension;
     bool finished;
     int32_t pos_on_r;
@@ -58,8 +70,18 @@ class ReadProcessor {
         void next_kmer_search(Strand& process);
         void next_kmer_search_negative_skip_all_heuristic(Strand& process);
         bool verify_kmer(Strand& process, uint64_t k);
+
+#if MODE == 5 or MODE == 7
+    void process_char_tally(Strand& process);
+    void find_next_id(Strand& process);
+    void count_rows_untill_tally(Strand& process);
+    void find_tally_b(Strand& process);
+    void process_latency_hiding_tally();
+#endif
     private:
         MoveStructure& mv;
+        int cache_line_size;
+        int prefetch_step;
         gzFile fp;
         kseq_t *seq;
         int l;

--- a/include/read_processor.hpp
+++ b/include/read_processor.hpp
@@ -28,6 +28,7 @@ struct Strand {
     bool id_found;
     uint8_t char_index;
     uint16_t tally_offset;
+    int find_next_id_attempt;
 #endif
 
     bool kmer_extension;

--- a/include/sequitur.hpp
+++ b/include/sequitur.hpp
@@ -9,7 +9,11 @@ struct KmerStatistics {
         return positive_kmers + negative_kmers;
     }
 
-    void print() {
+    void print(bool count_query = false) {
+        std::cout << "\n\nNumber of kmers found in the index:\t" << positive_kmers << "\n";
+        if (count_query)
+            std::cout << "Sum of the counts of found k-mers:\t" << total_counts << "\n\n\n";
+
         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
         std::cout << "total_kmers:\t\t" <<  total_kmers() << "\n";
         std::cout << "positive_skipped:\t" << positive_skipped << "\t"
@@ -24,8 +28,10 @@ struct KmerStatistics {
                     << std::setprecision(2) << 100 * static_cast<double>(backward_search_empty) / static_cast<double>(total_kmers()) << "%\n";
         std::cout << "right_extension_failed:\t" << right_extension_failed << "\t"
                     << std::setprecision(2) << 100 * static_cast<double>(right_extension_failed) / static_cast<double>(total_kmers()) << "%\n";
+
         std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
     }
+    uint64_t total_counts = 0;
     uint64_t positive_kmers = 0;
     uint64_t positive_skipped = 0;
     uint64_t look_ahead_skipped = 0;

--- a/include/sequitur.hpp
+++ b/include/sequitur.hpp
@@ -1,0 +1,32 @@
+
+#ifndef __SEQUITUR__
+#define __SEQUITUR__
+
+struct KmerStatistics {
+    uint64_t total_kmers() {
+        return positive_kmers + look_ahead_skipped + initialize_skipped + backward_search_failed + backward_search_empty;
+    }
+    void print() {
+        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
+        std::cout << "total_kmers:\t\t" <<  total_kmers() << "\n";
+        std::cout << "positive_skipped:\t" << positive_skipped << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(positive_skipped) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "backward_search_failed:\t" << backward_search_failed << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(backward_search_failed) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "look_ahead_skipped:\t" << look_ahead_skipped << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(look_ahead_skipped) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "initialize_skipped:\t" << initialize_skipped << "\t"
+                    << std::setprecision(2) << 100 * static_cast<double>(initialize_skipped) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "backward_search_empty:\t" << backward_search_empty << "\t"
+                    << std::setprecision(2) << 100 * static_cast<double>(backward_search_empty) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
+    }
+    uint64_t positive_kmers = 0;
+    uint64_t positive_skipped = 0;
+    uint64_t look_ahead_skipped = 0;
+    uint64_t initialize_skipped = 0;
+    uint64_t backward_search_failed = 0;
+    uint64_t backward_search_empty = 0;
+};
+
+#endif

--- a/include/sequitur.hpp
+++ b/include/sequitur.hpp
@@ -4,8 +4,11 @@
 
 struct KmerStatistics {
     uint64_t total_kmers() {
-        return positive_kmers + look_ahead_skipped + initialize_skipped + backward_search_failed + backward_search_empty;
+        uint64_t negative_kmers = look_ahead_skipped + initialize_skipped + backward_search_failed + backward_search_empty +
+                                  right_extension_failed;
+        return positive_kmers + negative_kmers;
     }
+
     void print() {
         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
         std::cout << "total_kmers:\t\t" <<  total_kmers() << "\n";
@@ -19,6 +22,8 @@ struct KmerStatistics {
                     << std::setprecision(2) << 100 * static_cast<double>(initialize_skipped) / static_cast<double>(total_kmers()) << "%\n";
         std::cout << "backward_search_empty:\t" << backward_search_empty << "\t"
                     << std::setprecision(2) << 100 * static_cast<double>(backward_search_empty) / static_cast<double>(total_kmers()) << "%\n";
+        std::cout << "right_extension_failed:\t" << right_extension_failed << "\t"
+                    << std::setprecision(2) << 100 * static_cast<double>(right_extension_failed) / static_cast<double>(total_kmers()) << "%\n";
         std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
     }
     uint64_t positive_kmers = 0;
@@ -27,6 +32,7 @@ struct KmerStatistics {
     uint64_t initialize_skipped = 0;
     uint64_t backward_search_failed = 0;
     uint64_t backward_search_empty = 0;
+    uint64_t right_extension_failed = 0;
 };
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,0 +1,24 @@
+#ifndef __UTILS__
+#define __UTILS__
+
+#include <sys/stat.h> 
+
+#include <string>
+#include <vector>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include "move_query.hpp"
+
+char complement(char c);
+
+std::string reverse_complement(std::string& fw);
+
+std::string reverse_complement_from_pos(MoveQuery& mq_fw, int32_t pos_on_r, uint64_t match_len);
+
+std::string number_to_kmer(size_t j, size_t m, std::vector<unsigned char>& alphabet, std::vector<uint64_t>& alphamap);
+
+uint64_t kmer_to_number(size_t k, std::string& r, int32_t pos, std::vector<uint64_t>& alphamap, bool rc = false) ;
+
+#endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,4 +21,6 @@ std::string number_to_kmer(size_t j, size_t m, std::vector<unsigned char>& alpha
 
 uint64_t kmer_to_number(size_t k, std::string& r, int32_t pos, std::vector<uint64_t>& alphamap, bool rc = false) ;
 
+uint8_t F_char(std::vector<uint64_t>& first_runs, uint64_t run);
+
 #endif

--- a/src/move_row.cpp
+++ b/src/move_row.cpp
@@ -156,15 +156,15 @@ void MoveRow::set_offset(uint16_t offset_) {
 // 00000000 00000000 00000000 11000011 11000011 11000011 00000000 00000000
 // >> 16
 // 00000000 00000000 00000000 00000000 00000000 11000000 11000011 11000011
-// << 11
-// 00000000 00000000 00000000 00000110 00000110 00011110 00011000 00000000
-//                                                       11111000 00000000
+// << 10
+// 00000000 00000000 00000000 00000110 00000011 00001111 00001100 00000000
+//                                                       11111100 00000000
 
 // 00000000 00000000 00000000 11000011 11000011 11000011 00000000 00000000
-// >> 21
-// 00000000 00000000 00000000 00000000 00000000 00000110 00011110 00011110
+// >> 22
+// 00000000 00000000 00000000 00000000 00000000 00000011 00001111 00001111
 // << 14
-// 00000000 00000000 00000000 00000001 10000111 10000111 10000000 00000000
+// 00000000 00000000 00000000 00000000 11000011 11000011 110000000 0000000
 //                                                       11000000 00000000
 void MoveRow::set_id(uint64_t id_) {
     id = id_; // Store the least significant bits in the didicated id variable
@@ -177,10 +177,9 @@ void MoveRow::set_id(uint64_t id_) {
 
     n = n & mask_id1;
     n = n | ((id_ >> 16) << SHIFT_ID1);
-#if MODE == 3
     offset = offset & mask_id2;
+    //Note: SHIFT_ID1_RES = 16 + ID_SIG_BITS1
     offset = offset | ((id_ >> (16 + ID_SIG_BITS1)) << SHIFT_ID2);
-#endif
 }
 
 void MoveRow::set_c(char c_, std::vector<uint64_t>& alphamap) {
@@ -199,15 +198,15 @@ void MoveRow::set_threshold(uint16_t i, uint16_t value) {
     switch (i) {
         case 0:
             offset = offset & mask_thresholds1;
-            offset = offset | (value << 13);
+            offset = offset | (value << 12);
             break;
         case 1:
             offset = offset & mask_thresholds2;
-            offset = offset | (value << 14);
+            offset = offset | (value << 13);
             break;
         case 2:
             offset = offset & mask_thresholds3;
-            offset = offset | (value << 15);
+            offset = offset | (value << 14);
             break;
         default:
             std::cerr << "Only three thresholds may be stored: " << i << "\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -977,18 +977,19 @@ void MoveStructure::build() {
 #if MODE == 5 or MODE == 7
         rlbwt[r_idx].init(len, offset);
 
-        // Only update the tally corresponding to the current run's character
-        uint16_t char_index = alphamap[bwt_string[all_p[r_idx]]];
-
-        // The first tally id might have been set to the wrong value since no run with that character was observed
-        // So, we fix the values once we the first run with that character
-        if (current_tally_ids[char_index] == r) {
-            uint64_t tally_ids_index = r_idx / TALLY_CHECKPOINTS;
-            for (int tid = 0; tid <= tally_ids_index; tid++) {
-                tally_ids[char_index][tid].set_value(pp_id);
+        if (r_idx != end_bwt_idx) {
+            // Only update the tally corresponding to the current run's character
+            uint16_t char_index = alphamap[bwt_string[all_p[r_idx]]];
+            // The first tally id might have been set to the wrong value since no run with that character was observed
+            // So, we fix the values once we the first run with that character
+            if (current_tally_ids[char_index] == r) {
+                uint64_t tally_ids_index = r_idx / TALLY_CHECKPOINTS;
+                for (int tid = 0; tid <= tally_ids_index; tid++) {
+                    tally_ids[char_index][tid].set_value(pp_id);
+                }
             }
+            current_tally_ids[char_index] = pp_id;
         }
-        current_tally_ids[char_index] = pp_id;
 
         if (r_idx % TALLY_CHECKPOINTS == 0) {
             uint64_t tally_ids_index = r_idx / TALLY_CHECKPOINTS;

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1769,12 +1769,22 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
 
 bool MoveStructure::extend_left(char c, MoveBiInterval& bi_interval) {
     char c_ = c;
-    return extend_bidirectional(c_, bi_interval.fw_interval, bi_interval.rc_interval);
+    if (extend_bidirectional(c_, bi_interval.fw_interval, bi_interval.rc_interval)) {
+        bi_interval.match_len += 1;
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool MoveStructure::extend_right(char c, MoveBiInterval& bi_interval) {
     char c_ = complement(c);
-    return extend_bidirectional(c_, bi_interval.rc_interval, bi_interval.fw_interval);
+    if (extend_bidirectional(c_, bi_interval.rc_interval, bi_interval.fw_interval)) {
+        bi_interval.match_len += 1;
+        return true;
+    } else {
+        return false;
+    }
 }
 
 MoveBiInterval MoveStructure::backward_search_bidirectional(std::string& R, int32_t& pos_on_r, MoveBiInterval interval, int32_t max_length) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -387,7 +387,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
     }
 
 
-    // If we are at a checkpoint, simply returnt the stored id
+    // If we are at a checkpoint, simply return the stored id
     if (idx % TALLY_CHECKPOINTS == 0) {
         id = tally_ids[char_index][tally_a].get();
         return tally_ids[char_index][tally_a].get();
@@ -434,7 +434,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
         // dbg << "from: " << idx << " to: " << next_check_point << "\n";
         for (uint64_t i = idx; i < next_check_point; i++) {
             // Only count the rows with the same character
-            if (rlbwt[i].get_c() == rlbwt[idx].get_c()) {
+            if (get_char(i) == get_char(idx)) {
                 rows_until_tally += get_n(i);
                 last_id = i;
             }
@@ -442,7 +442,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
 
         // The id stored at the checkpoint is actually the id for the current run
         // because there was no run with the same character between the current run and the next_check_point
-        if (last_id == idx and rlbwt[idx].get_c() != rlbwt[next_check_point].get_c()) {
+        if (last_id == idx and get_char(idx) != get_char(next_check_point)) {
             return id;
         }
         if (last_id == r) {
@@ -459,7 +459,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
         // So, we have to decrease the number of rows of the last run as they are not between the current run
         // and the run for which we know the id
         // Also, for other characters, offset should be stored based on that run (not the checkpoint run)
-        if (rlbwt[idx].get_c() != rlbwt[next_check_point].get_c()) {
+        if (get_char(idx) != get_char(next_check_point)) {
             rows_until_tally -= get_n(last_id);
             offset = get_offset(last_id);
         }
@@ -486,6 +486,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
             }
         }
     // }
+
     return id;
 #endif
 }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2940,7 +2940,7 @@ void MoveStructure::print_ids() {
             uint64_t adjusted_id = id - first_runs[rlbwt[i].get_c() + 1];
 
             int char_index = static_cast<int>(rlbwt[i].get_c());
-            *id_files[char_index] << adjusted_id << "\n";
+            *id_files[char_index] << adjusted_id << "\t" << i << "\n";
 
             ids_all << adjusted_id << "\n";
         }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -752,6 +752,8 @@ void MoveStructure::build() {
     original_r = 1;
     // TODO Use a size based on the input size
 
+    uint64_t split_by_max_run = 0;
+
     // A any mode with splitting (modes 1 and 4) does not work with the preprocessed build
     if (movi_options->is_preprocessed()) {
         length = static_cast<uint64_t>(end_pos);
@@ -785,6 +787,7 @@ void MoveStructure::build() {
 #if MODE == 3 or MODE == 5 or MODE == 6 or MODE == 7
             size_t remaining_length = len;
             while (remaining_length > MAX_RUN_LENGTH) {
+                split_by_max_run += 1;
                 lens.push_back(MAX_RUN_LENGTH);
                 heads.push_back(heads_[i]);
                 remaining_length -= MAX_RUN_LENGTH;
@@ -871,6 +874,8 @@ void MoveStructure::build() {
                     original_r += 1;
                 }
             } else if (run_length == MAX_RUN_LENGTH) {
+                if (!(bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]))
+                    split_by_max_run += 1;
                 r += 1;
                 run_length = 0;
                 bits[bwt_curr_length] = 1;
@@ -946,6 +951,8 @@ void MoveStructure::build() {
         }
         std::cerr << "\nAll the Occ bit vectors are built.\n";
     }
+    std::cerr << "split_by_max_run: " << split_by_max_run << "\n";
+
     std::cerr << "length: " << length << "\n";
     std::cerr << "\n\nr: " << r << "\n";
     std::cerr << "original_r: " << original_r << "\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2923,6 +2923,8 @@ void MoveStructure::print_ids() {
     std::string base_name = movi_options->get_index_dir() + "/ids";
     std::vector<std::unique_ptr<std::ofstream>> id_files;
 
+    std::ofstream ids_all(base_name + ".all");
+
     for (int i = 0; i < alphabet.size(); i++) {
         std::string ext(1, alphabet[i]);
         id_files.push_back(std::make_unique<std::ofstream>(base_name + "." + ext));
@@ -2939,7 +2941,14 @@ void MoveStructure::print_ids() {
 
             int char_index = static_cast<int>(rlbwt[i].get_c());
             *id_files[char_index] << adjusted_id << "\n";
+
+            ids_all << adjusted_id << "\n";
         }
+    }
+
+    ids_all.close();
+    for (auto& id_file : id_files) {
+        id_file->close();
     }
 
     std::cerr << "\nDone.\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -208,13 +208,13 @@ uint32_t MoveStructure::compute_index(char row_char, char lookup_char) {
         return alpha_index+1;*/
 }
 
-uint16_t MoveStructure::LF_move(uint64_t& offset, uint64_t& i) {
+uint16_t MoveStructure::LF_move(uint64_t& offset, uint64_t& i, uint64_t id) {
     /* if (movi_options->is_verbose()) {
         std::cerr << "\t in LF:\n";
         std::cerr << "\t \t i: " << i << " offset: " << offset << "\n";
     } */
     auto& row = rlbwt[i];
-    auto idx = get_id(i);
+    auto idx = (id == std::numeric_limits<uint64_t>::max()) ? get_id(i) : id;
     if (idx >= r) {
         std::cerr << "This should not happen.\n";
         std::cerr << "idx:::" << idx << " i:" << i << "\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2625,7 +2625,6 @@ void MoveStructure::serialize() {
     fout.write(reinterpret_cast<char*>(&first_runs[0]), first_runs.size()*sizeof(first_runs[0]));
     fout.write(reinterpret_cast<char*>(&first_offsets[0]), first_offsets.size()*sizeof(first_offsets[0]));
 
-<<<<<<< HEAD
 #if MODE == 3 or MODE == 6
     if (id_blocks.size() > 0) {
         uint64_t id_blocks_size = id_blocks[0].size();
@@ -2638,9 +2637,7 @@ void MoveStructure::serialize() {
         fout.write(reinterpret_cast<char*>(&id_blocks_size), sizeof(id_blocks_size));
     }
 #endif
-=======
     fout.write(reinterpret_cast<char*>(&original_r), sizeof(original_r));
->>>>>>> 12bfa00... write the original_r value into the index
 
     fout.close();
 }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -789,7 +789,7 @@ void MoveStructure::build() {
                 std::cerr << "original_r: " << original_r << "\t";
                 std::cerr << "bwt_curr_length: " << bwt_curr_length << "\r";
             }
-#if MODE == 3 or or MODE == 5 MODE == 6
+#if MODE == 3 or MODE == 5 or MODE == 6
             // The first row is already set and accounted for, so we skip
             if (movi_options->is_thresholds() and bwt_curr_length > 0 and bits[bwt_curr_length] == 1) {
                 // The bit was already set by one of the threshold values

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1398,8 +1398,9 @@ void MoveStructure::compute_thresholds() {
                 }
                 if (alphabet_thresholds[j] >= all_p[i] + get_n(i)) {
                     // rlbwt[i].thresholds[j] = get_n(i);
-                    if (rlbwt_c == END_CHARACTER) {
+                    if (i == end_bwt_idx) {
                         end_bwt_idx_thresholds[j] = get_n(i);
+                        std::cerr << "condition 1: end_bwt_idx_thresholds[" << j << "]:" << end_bwt_idx_thresholds[j] << "\n";
                         continue;
                     }
 #if MODE == 0 or MODE == 1 or MODE == 4
@@ -1414,8 +1415,9 @@ void MoveStructure::compute_thresholds() {
 #endif
                     current_thresholds[alphamap_3[alphamap[rlbwt_c]][j]] = get_n(i);
                 } else if (alphabet_thresholds[j] <= all_p[i]) {
-                    if (rlbwt_c == END_CHARACTER) {
+                    if (i == end_bwt_idx) {
                         end_bwt_idx_thresholds[j] = 0;
+                        std::cerr << "condition 2: end_bwt_idx_thresholds[" << j << "]:" << end_bwt_idx_thresholds[j] << "\n";
                         continue;
                     }
 #if MODE == 0 or MODE == 1 or MODE == 4
@@ -1426,8 +1428,9 @@ void MoveStructure::compute_thresholds() {
 #endif
                     current_thresholds[alphamap_3[alphamap[rlbwt_c]][j]] = 0;
                 } else {
-                    if (rlbwt_c == END_CHARACTER) {
+                    if (i == end_bwt_idx) {
                         end_bwt_idx_thresholds[j] = alphabet_thresholds[j] - all_p[i];
+                        std::cerr << "condition 3: end_bwt_idx_thresholds[" << j << "]:" << end_bwt_idx_thresholds[j] << "\n";
                         continue;
                     }
 #if MODE == 0 or MODE == 1 or MODE == 4
@@ -2509,7 +2512,6 @@ uint64_t MoveStructure::query_pml(MoveQuery& mq, bool random) {
         auto& row = rlbwt[idx];
         uint64_t row_idx = idx;
         char row_c = alphabet[row.get_c()];
-
         if (!check_alphabet(R[pos_on_r])) {
             // The character from the read does not exist in the reference
             match_len = 0;
@@ -2620,7 +2622,8 @@ bool MoveStructure::jump_thresholds(uint64_t& idx, uint64_t offset, char r_char,
 
     if (idx == end_bwt_idx) {
         if (movi_options->is_verbose()) std::cerr << "\t \t \t idx == end_bwt_idx"
-                                << "\n\t \t \t idx: " << idx << " end_bwt_idx: " << end_bwt_idx << "\n";
+                                << "\n\t \t \t idx: " << idx << " end_bwt_idx: " << end_bwt_idx << " alphabet_index: " << alphabet_index << "\n"
+                                << "\t \t \t end_bwt_idx_thresholds[alphabet_index]: " << end_bwt_idx_thresholds[alphabet_index] << "\n";
         if (offset >= end_bwt_idx_thresholds[alphabet_index]) {
             if (movi_options->is_verbose())
                 std::cerr << "\t \t \t Jumping down with thresholds:\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -101,7 +101,7 @@ std::string MoveStructure::index_type() {
     return "constant";
 #endif
 #if MODE == 3
-    return "compact";
+    return "blocked";
 #endif
 #if MODE == 4
     // Like the default constant mode, but without the pointers to the neighbors with the other characters
@@ -111,7 +111,7 @@ std::string MoveStructure::index_type() {
     return "tally";
 #endif
 #if MODE == 6
-    return "compact-thresholds";
+    return "blocked-thresholds";
 #endif
 #if MODE == 7
     return "tally-thresholds";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -860,6 +860,7 @@ void MoveStructure::build() {
             // if (current_char != 'A' and current_char != 'C' and current_char != 'G' and current_char != 'T')
             //    std::cerr << "\ncurrent_char:" << current_char << "---" << static_cast<uint64_t>(current_char) << "---\n";
             if (original_r % 100000 == 0) {
+                std::cerr << "r: " << r << "\t";
                 std::cerr << "original_r: " << original_r << "\t";
                 std::cerr << "bwt_curr_length: " << bwt_curr_length << "\r";
             }
@@ -892,10 +893,17 @@ void MoveStructure::build() {
 #if MODE == 0 or MODE == 1 or MODE == 4
             if (bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]) {
                 original_r += 1;
-                if (!splitting) bits[bwt_curr_length] = 1;
-            }
-            if (splitting && bwt_curr_length > 0 && bits[bwt_curr_length]) {
                 r += 1;
+                run_length = 0;
+                bits[bwt_curr_length] = 1;
+            } else if (splitting && bwt_curr_length > 0 && bits[bwt_curr_length]) {
+                r += 1;
+                run_length = 0;
+            } else if (run_length == MAX_RUN_LENGTH) {
+                split_by_max_run += 1;
+                r += 1;
+                run_length = 0;
+                bits[bwt_curr_length] = 1;
             }
 #endif
             bwt_string[bwt_curr_length] = current_char;
@@ -904,10 +912,13 @@ void MoveStructure::build() {
 
             current_char = bwt_file.get();
         }
-#if MODE == 0 or MODE == 1 or MODE == 4
-        if (!splitting) r = original_r;
-#endif
+// #if MODE == 0 or MODE == 1 or MODE == 4
+// r is laready set to r' which might be larger than r because of the length splitting
+// so, we don't have to set it back to original_r anymore (the next line is commented)
+//         if (!splitting) r = original_r;
+// #endif
         length = bwt_curr_length; // bwt_string.length();
+        std::cerr << "\nsplit_by_max_run: " << split_by_max_run << "\n";
         std::cerr << "length: " << length << "\n";
 
         // Building the auxilary structures
@@ -951,7 +962,6 @@ void MoveStructure::build() {
         }
         std::cerr << "\nAll the Occ bit vectors are built.\n";
     }
-    std::cerr << "split_by_max_run: " << split_by_max_run << "\n";
 
     std::cerr << "length: " << length << "\n";
     std::cerr << "\n\nr: " << r << "\n";
@@ -1087,6 +1097,8 @@ void MoveStructure::build() {
 #endif
 #if MODE == 0 or MODE == 1 or MODE == 4
         if (len > MAX_RUN_LENGTH) {
+            std::cerr << "This shouldn't happen anymore, because the run splitting should be applied in every mode now.\n";
+            exit(0);
             n_overflow.push_back(len);
             if (n_overflow.size() - 1 >= MAX_RUN_LENGTH) {
                 std::cerr << "Warning: the number of runs with overflow n is beyond " << MAX_RUN_LENGTH<< "! " << n_overflow.size() - 1 << "\n";
@@ -1096,6 +1108,8 @@ void MoveStructure::build() {
             rlbwt[r_idx].set_overflow_n();
         }
         if (offset > MAX_RUN_LENGTH) {
+            std::cerr << "This shouldn't happen anymore, because the run splitting should be applied in every mode now.\n";
+            exit(0);
             offset_overflow.push_back(offset);
             if (offset_overflow.size() - 1 >= MAX_RUN_LENGTH) {
                 std::cerr << "Warning: the number of runs with overflow offset is beyond " << MAX_RUN_LENGTH<< "! " << offset_overflow.size() - 1 << "\n";

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2615,6 +2615,7 @@ void MoveStructure::serialize() {
     fout.write(reinterpret_cast<char*>(&first_runs[0]), first_runs.size()*sizeof(first_runs[0]));
     fout.write(reinterpret_cast<char*>(&first_offsets[0]), first_offsets.size()*sizeof(first_offsets[0]));
 
+<<<<<<< HEAD
 #if MODE == 3 or MODE == 6
     if (id_blocks.size() > 0) {
         uint64_t id_blocks_size = id_blocks[0].size();
@@ -2627,6 +2628,9 @@ void MoveStructure::serialize() {
         fout.write(reinterpret_cast<char*>(&id_blocks_size), sizeof(id_blocks_size));
     }
 #endif
+=======
+    fout.write(reinterpret_cast<char*>(&original_r), sizeof(original_r));
+>>>>>>> 12bfa00... write the original_r value into the index
 
     fout.close();
 }
@@ -2737,6 +2741,12 @@ void MoveStructure::deserialize() {
         }
     }
 #endif
+    // To be able to load the indexes that haven't stored original_r
+    if (fin.eof()) {
+        std::cerr << "original_r was not stored in the index!\n";
+    } else {
+        fin.read(reinterpret_cast<char*>(&original_r), sizeof(original_r));
+    }
 
     fin.close();
 }
@@ -2780,6 +2790,7 @@ void MoveStructure::verify_lfs() {
     if (not_matched == 0) {
         std::cerr << "All the LF_move operations are correct.\n";
     } else {
+        original_r = 0;
         std::cerr << "There are " << not_matched << " LF_move operations that failed to match the true lf results.\n";
     }
 }

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2880,6 +2880,9 @@ void MoveStructure::print_stats() {
         std::cerr << "n/original_r: " << length/original_r << "\n";
     }
     std::cerr << "Size of the rlbwt table: " << sizeof(rlbwt[0]) * rlbwt.size() * (0.000000001) << "\n";
+#if MODE == 3 or MODE == 6
+    std::cerr << "Size of the block table: " << sizeof(id_blocks[0][0]) * id_blocks[0].size() * id_blocks.size() * (0.000000001) << "\n";
+#endif
 #if MODE == 5 or MODE == 7
     std::cerr << "Size of the tally table: " << sizeof(tally_ids[0][0]) * tally_ids[0].size() * tally_ids.size() * (0.000000001) << "\n";
 #endif

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1,12 +1,12 @@
 #include <sys/stat.h> 
 
 #include "move_structure.hpp"
+#include "utils.hpp"
 
 uint32_t alphamap_3[4][4] = {{3, 0, 1, 2},
                              {0, 3, 1, 2},
                              {0, 1, 3, 2},
                              {0, 1, 2, 3}};
-std::ostringstream dbg;
 
 void read_thresholds(std::string tmp_filename, sdsl::int_vector<>& thresholds) {
     int log_n = 100;
@@ -468,7 +468,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
 
         // Sanity check, the offset in the destination run should be always smaller than the length of that run
         if (offset >= get_n(id)) {
-            std::cout << "offset: " << offset << " n: " << get_n(id) << "\n" << dbg.str() << "\n";
+            std::cout << "offset: " << offset << " n: " << get_n(id) << "\n"; // << dbg.str() << "\n";
             exit(0);
         }
         if (offset >= rows_until_tally) {
@@ -530,7 +530,7 @@ uint64_t MoveStructure::get_id(uint64_t idx) {
         // Sanity check, the offset in the destination run should be always smaller than the length of that run
         if (offset >= get_n(id)) {
             std::cout << "idx: " << idx << " last_id: " << last_id << " id: " << id << " prev_check_point: " << prev_check_point << "\n";
-            std::cout << "offset: " << offset << " n: " << get_n(id) << "\n" << dbg.str() << "\n";
+            std::cout << "offset: " << offset << " n: " << get_n(id) << "\n"; // << dbg.str() << "\n";
             exit(0);
         }
         if ((get_n(id) - offset - 1) >= rows_until_tally) {
@@ -1273,53 +1273,6 @@ void MoveStructure::compute_run_lcs() {
     }
 }
 
-char complement(char c) {
-    // # is the separator, complement(#) = #
-    char c_comp = c == '#' ? '#' : (c == 'A' ? 'T' : ( c == 'C' ? 'G' : (c == 'G' ? 'C' : 'A')));
-    return c_comp;
-}
-
-std::string reverse_complement(std::string& fw) {
-    std::string rc = "";
-    rc.resize(fw.size());
-    for (int i = fw.size() - 1;  i >= 0; i--) {
-        rc[fw.size() - i - 1] = complement(fw[i]);
-    }
-    return rc;
-}
-
-uint64_t kmer_to_number(size_t k, std::string& r, int32_t pos, std::vector<uint64_t>& alphamap, bool rc = false) {
-    if (r.length() < k) {
-        std::cerr << "The k does not match the kmer length!\n";
-        exit(0);
-    }
-
-    uint64_t res = 0;
-    for (size_t i = 0; i < k; i++) {
-        if (alphamap[static_cast<uint64_t>(r[pos + i])] == alphamap.size()) {
-            return std::numeric_limits<uint64_t>::max();
-        }
-        if (rc) {
-            uint64_t char_code = alphamap[complement(r[pos + i])] - alphamap['A'];
-            res = (char_code << ((i)*2)) | res;
-        } else {
-            uint64_t char_code = alphamap[r[pos + i]] - alphamap['A'];
-            res = (char_code << ((k-i-1)*2)) | res;
-        }
-    }
-    return res;
-}
-
-std::string number_to_kmer(size_t j, size_t m, std::vector<unsigned char>& alphabet, std::vector<uint64_t>& alphamap) {
-    std::string kmer = "";
-    for (int i = m - 2; i >= 0; i -= 2) {
-        size_t pair = (j >> i) & 0b11;
-        // std::cerr << i << " " << pair << " ";
-        kmer += alphabet[pair + alphamap['A']];
-    }
-    return kmer;
-}
-
 void MoveStructure::compute_ftab() {
     size_t ftab_k = movi_options->get_ftab_k();
 
@@ -1684,14 +1637,14 @@ void MoveStructure::update_interval(MoveInterval& interval, char next_char) {
     }
 #endif
 #if MODE == 1
-    if (movi_options->is_debug())
-        dbg << alphabet[rlbwt[interval.run_start].get_c()] << " " << alphabet[rlbwt[interval.run_end].get_c()] << " " << next_char << "\n";
+    // if (movi_options->is_debug())
+    //     dbg << alphabet[rlbwt[interval.run_start].get_c()] << " " << alphabet[rlbwt[interval.run_end].get_c()] << " " << next_char << "\n";
     uint64_t read_alphabet_index = alphamap[static_cast<uint64_t>(next_char)];
     if ((interval.run_start <= interval.run_end) and (alphabet[rlbwt[interval.run_start].get_c()] != next_char)) {
         if (interval.run_start == 0) {
             // To check if this case ever happens. If not, we should get rid of this condition.
-            if (movi_options->is_debug())
-                dbg << "run_start is 0 before updating the interval!\n";
+            // if (movi_options->is_debug())
+            //     dbg << "run_start is 0 before updating the interval!\n";
             while ((interval.run_start <= interval.run_end) and (alphabet[rlbwt[interval.run_start].get_c()] != next_char)) {
                 interval.run_start += 1;
                 interval.offset_start = 0;
@@ -1878,15 +1831,6 @@ MoveInterval MoveStructure::try_ftab(MoveQuery& mq, int32_t& pos_on_r, uint64_t&
     MoveInterval empty_interval;
     empty_interval.make_empty();
     return empty_interval;
-}
-
-std::string reverse_complement_from_pos(MoveQuery& mq_fw, int32_t pos_on_r, uint64_t match_len) {
-    std::string rc = "";
-    rc.resize(match_len);
-    for (int i = pos_on_r + match_len - 1;  i >= pos_on_r; i--) {
-        rc[pos_on_r + match_len - 1 - i] = complement(mq_fw.query()[i]);
-    }
-    return rc;
 }
 
 MoveBiInterval MoveStructure::initialize_bidirectional_search(MoveQuery& mq, int32_t& pos_on_r, uint64_t& match_len) {
@@ -2081,323 +2025,6 @@ bool MoveStructure::look_ahead_backward_search(MoveQuery& mq, uint32_t pos_on_r,
         return true;
     } else {
         return false;
-    }
-}
-
-// pos_on_r points to the furthest base of the kmer to be searched
-// The search is from the right end of the kmer
-// All kmers on the right side of the kmer_middle might be found in this call if they exist
-uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& pos_on_r) {
-    uint64_t kmers_found = 0;
-    int32_t last_kmer_looked_at = pos_on_r;
-
-    size_t ftab_k = movi_options->get_ftab_k();
-    size_t k = movi_options->get_k();
-    auto& query_seq = mq.query();
-
-    // The middle point of the kmer
-    int32_t kmer_middle = pos_on_r - k/2;
-    // To remember the kmer which initiated the search
-    int32_t pos_on_r_saved = pos_on_r;
-    // The number of bases matched so far
-    uint64_t match_len = 0;
-    // The position of the left side of the kmer on the read
-    int32_t kmer_left = pos_on_r - k + 1;
-    // The position on the right side of the match to be found by ftab
-    int32_t ftab_right = kmer_left + ftab_k - 1;
-
-    // At the time, the initialization works if ftab with ftab_k exists only
-    // And the multi-ftab strategy must be turned off
-    movi_options->set_multi_ftab(false);
-
-    MoveBiInterval bi_interval;
-    int32_t ftab_right_initialize = ftab_right;
-
-    bi_interval = initialize_bidirectional_search(mq, ftab_right_initialize, match_len);
-
-    if (match_len == 0 and ftab_k > 1) {
-        // If the ftab-k-mer at the end of the read is not found,
-        // we can skip all the kmers until ftab_right - 1
-        kmer_stats.initialize_skipped += 1;
-        pos_on_r = ftab_right - 1;
-        return 0;
-    }
-
-    // pos_on_r and pos_on_r_saved point to the beginning of the kmer for which the bidirectional initialization was performed above
-    // Extend to right until the kmer is found and save the observed intervals beyond k/2
-    std::vector<MoveBiInterval> partial_matches;
-    partial_matches.resize(k);
-    // kmer_right is the last position matched so far
-    uint64_t kmer_right = ftab_right;
-    int here = 0;
-    while (kmer_right < pos_on_r_saved) {
-        // The next k-mer we are looking at, ends at next_pos
-        int next_pos = kmer_right + 1;
-
-        if (movi_options->is_debug() and next_pos >= k)
-            dbg << "\nkmer at " << next_pos << ": " << query_seq.substr(next_pos - k + 1, k) << " ";
-
-        bool extend_right_res = extend_right(query_seq[next_pos], bi_interval);
-        if (!extend_right_res) {
-            here = 1;
-            // The kmer was not found, we can skip kmers until ftab_right
-            pos_on_r = kmer_right;
-            last_kmer_looked_at = next_pos;
-
-            // Printing all the kmers being skipped, because the extension to the right was not possible
-            if (movi_options->is_debug()) {
-                int j = next_pos + 1;
-                while (j < pos_on_r_saved) {
-                    if (j > k)
-                        dbg << "\nkmer at " << j << ": " << query_seq.substr(j - k + 1, k) << "-";
-                    j += 1;
-                }
-            }
-
-            // It's important to break here, to avoid false extensions in the following iterations
-            break;
-        } else {
-            match_len += 1;
-            kmer_right = next_pos;
-            bi_interval.match_len = match_len;
-            // store the intervals for matches beyond half point of the kmer
-            if (kmer_right > kmer_middle and kmer_right != pos_on_r) {
-                bi_interval.match_len = match_len;
-                // "kmer_right - kmer_left" is the index of the kmer from the left end
-                partial_matches[kmer_right - kmer_left] = bi_interval;
-            }
-        }
-    }
-
-    if (kmer_right == pos_on_r_saved) {
-        // The kmer at pos_on_r was found by k bidirectional backward search
-        kmers_found += 1;
-        kmer_stats.backward_search_empty += 1;
-        // std::cerr << "The first kmer at " << pos_on_r << " was found.\n";
-        pos_on_r = pos_on_r_saved - 1;
-        // To avoid searching this kmer again in the next step
-        kmer_right -= 1;
-
-        if (movi_options->is_debug()) {
-            if (pos_on_r_saved > k)
-                dbg << "\nkmer at " << pos_on_r_saved << ": " << query_seq.substr(pos_on_r_saved - k + 1, k) << "\n";
-            dbg << "1";
-        }
-
-    } else {
-        if (movi_options->is_debug()) {
-            if (pos_on_r_saved > k)
-                dbg << "\nkmer at " << pos_on_r_saved << ": " << query_seq.substr(pos_on_r_saved - k + 1, k) << "-\n";
-            dbg << "0";
-        }
-    }
-
-
-    // Use partial matches for finding other overlapping kmers (until half point)
-    if (kmer_right > kmer_middle) {
-        if (movi_options->is_debug()) {
-            for (int i = kmer_right + 1; i < pos_on_r_saved; i++) {
-                dbg << "0";
-            }
-        }
-        for (uint i = kmer_right; i > kmer_middle; i--) {
-            // Set kmer_left_ext to be the last match position on the left end
-            int32_t kmer_left_ext = kmer_left;
-            auto& partial_match_interval = partial_matches[i - kmer_left];
-            last_kmer_looked_at = i;
-            while (partial_match_interval.match_len < k and kmer_left_ext > 0) {
-                // We don't need to do bidirectional left extension here, simple backward search is enough
-                bool res = backward_search_step(query_seq[kmer_left_ext - 1], partial_match_interval.fw_interval);
-                // bool res = extend_left(query_seq[kmer_left_ext - 1], partial_match_interval);
-                if (!res) {
-                    // The current kmer is not present, move to the next partial match by breaking from the inner loop
-                    break;
-                } else {
-                    kmer_left_ext -= 1;
-                    partial_match_interval.match_len += 1;
-                }
-            }
-            if (partial_match_interval.match_len >= k) {
-                // The kmer was found by extending the partial match to left
-                kmers_found += 1;
-                kmer_stats.positive_skipped += 1;
-                if (movi_options->is_debug()) {
-                    std::cerr << "kmer at " << kmer_left_ext + k - 1 << " was found.\n";
-                    dbg << "1";
-                }
-            } else {
-                if (movi_options->is_debug()) {
-                    dbg << "0";
-                }
-            }
-
-            pos_on_r -= 1;
-        }
-        // At this point we have checked the presence of all the kmer beyond kmer_middle
-    } else {
-        // If we got here, we had to start the first while by breaking because of an unsuccessfull attempt to extend to the right
-        if (here != 1)
-            std::cerr << here << "\t" << last_kmer_looked_at << "\t" << pos_on_r << "\n";
-        if (kmer_right != pos_on_r)
-            std::cerr << "This should not happen: " << kmer_right << "\t" << pos_on_r << "\n";
-        // pos_on_r should have already been assigned to be the last kmer_right
-        // So we should never get here to do the assignment in practice
-        pos_on_r = kmer_right;
-
-        if (movi_options->is_debug()) {
-            for (int i = kmer_middle + 1; i <= pos_on_r_saved - 1; i++) {
-                dbg << "0";
-            }
-        }
-
-    }
-    return kmers_found;
-}
-
-uint64_t MoveStructure::query_kmers_from(MoveQuery& mq, int32_t& pos_on_r, bool single) {
-    size_t ftab_k = movi_options->get_ftab_k();
-    size_t k = movi_options->get_k();
-    auto& query_seq = mq.query();
-    int32_t pos_on_r_saved = pos_on_r;
-
-    // An alternative strategy to look ahead for possible skipping
-    // int32_t step = 0;
-    // if (ftab_k > 1 and !look_ahead_ftab(mq, pos_on_r, step)) {
-    //     kmer_stats.look_ahead_skipped += k - ftab_k - step;
-    //     pos_on_r = pos_on_r - k + ftab_k + step - 1;
-    //     pos_on_r_saved = pos_on_r;
-    // }
-
-    uint64_t match_len = 0;
-    MoveInterval initial_interval;
-    do {
-        initial_interval = initialize_backward_search(mq, pos_on_r, match_len);
-        if (match_len == 0 and ftab_k > 1) {
-            kmer_stats.initialize_skipped += 1;
-            pos_on_r -= 1;
-            pos_on_r_saved = pos_on_r;
-        }
-    } while (match_len == 0 and pos_on_r >= k - 1 and ftab_k > 1);
-
-    // I want to check how much slower it gets if turn off the positive skip:
-    auto backward_search_result = backward_search(query_seq, pos_on_r, initial_interval, single ? k - match_len - 2 : std::numeric_limits<int32_t>::max());
-
-    if (backward_search_result.is_empty()) {
-        // We get here when there is an illegal character at pos_on_r, just skip the current position
-        pos_on_r = pos_on_r_saved - 1;
-        kmer_stats.backward_search_empty += 1;
-        return 0;
-    } else {
-        if (pos_on_r_saved - pos_on_r >= k - 1) {
-            // At leat one kmer was found, update the postion and return the count
-            uint64_t kmers_found = pos_on_r_saved - pos_on_r - k + 2;
-            kmer_stats.positive_skipped += kmers_found - 1;
-
-            if (movi_options->is_debug()) {
-                int32_t pos_on_r_ = pos_on_r_saved;
-                auto backward_search_result_one_extra_base = backward_search(query_seq, pos_on_r_, initial_interval, k - match_len - 1);
-                dbg << backward_search_result.count(rlbwt) << "----" <<  backward_search_result_one_extra_base.count(rlbwt) << "\n";
-                dbg << backward_search_result << "\n";
-                if (backward_search_result.count(rlbwt) == backward_search_result_one_extra_base.count(rlbwt)) {
-                    // TODO: Use a counter to count the number of such incidents
-                } else {
-                }
-            }
-
-            pos_on_r = pos_on_r + k - 2;
-	        return kmers_found;
-        } else {
-            // No kmer was found, update the postion
-            kmer_stats.backward_search_failed += 1;
-            pos_on_r = pos_on_r_saved - 1;
-            return 0;
-        }
-    }
-}
-
-void MoveStructure::query_all_kmers(MoveQuery& mq, bool kmer_counts) {
-    size_t ftab_k = movi_options->get_ftab_k();
-    size_t k = movi_options->get_k();
-    auto& query_seq = mq.query();
-    int32_t pos_on_r = query_seq.length() - 1;
-
-    // To handle a special case for k equal to 1
-    if (k == 1) {
-        uint64_t kmers_found = 0;
-        while (pos_on_r >= 0) {
-            kmers_found += check_alphabet(query_seq[pos_on_r]) ? 1 : 0;
-            pos_on_r -= 1;
-        }
-        kmer_stats.positive_kmers += kmers_found;
-        return;
-    }
-
-    while (!check_alphabet(query_seq[pos_on_r])) {
-        pos_on_r -= 1; // Find the first position where the character is legal
-    }
-
-
-    int32_t step = k/3;
-    // k - step has to be always greater than ftab-k
-    if (k - step < ftab_k) {
-        step = k - ftab_k - 1;
-    }
-
-    while (pos_on_r >= k - 1) {
-        if (pos_on_r >= k -1 + step and !look_ahead_backward_search(mq, pos_on_r, step)) {
-            kmer_stats.look_ahead_skipped += step + 1;
-            pos_on_r = pos_on_r - step - 1;
-        } else {
-            if (kmer_counts) {
-                if (pos_on_r == k - 1) {
-                    kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
-                } else {
-                    kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);
-
-                    if (movi_options->is_debug()) {
-                        dbg.str("");
-                        dbg.clear();
-                        int pos_on_r_before = pos_on_r;
-                        int found_regular = 0;
-                        dbg << "regular backward search:\n";
-                        int k_m = pos_on_r - k/2;
-                        dbg << pos_on_r << "\t" << k_m << "\n";
-                        dbg << k/2 << "\n";
-                        for (int j = pos_on_r; j > k_m; j--) {
-                            dbg << " " << j << " ";
-                            if (j >= k)
-                                dbg << "\nkmer at " << j << ": " << query_seq.substr(j - k + 1, k) << " ";
-
-                            int pos = j;
-                            dbg << " pos:" << pos << " ";
-                            int z = query_kmers_from(mq, pos, true);
-                            if (z == 1 and pos == j - 1) {
-                                dbg << "1";
-                                found_regular += 1;
-                            } else
-                                dbg << "0";
-                        }
-                        dbg << "\n";
-                        dbg << "bidirectional search:\n";
-                        int pos = pos_on_r_before;
-                        int found_bidirectional = query_kmers_from_bidirectional(mq, pos);
-                        dbg << "\n";
-                        kmer_stats.positive_kmers += found_bidirectional;
-                        if (found_regular != found_bidirectional) {
-                            std::cerr << "pos_on_r_before:" << pos_on_r_before << " pos_on_r:" << pos_on_r
-                                    << " found_regular:" << found_regular << " found_bidirectional" << found_bidirectional << "\n";
-                            std::cerr << dbg.str() << std::endl;
-                        }
-                    }
-                }
-            } else {
-                kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
-            }
-        }
-
-        while (!check_alphabet(query_seq[pos_on_r])) {
-            pos_on_r -= 1; // Find the first position where the character is legal
-        }
     }
 }
 

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -753,6 +753,7 @@ void MoveStructure::build() {
     // TODO Use a size based on the input size
 
     uint64_t split_by_max_run = 0;
+    uint64_t split_by_thresholds = 0;
 
     // A any mode with splitting (modes 1 and 4) does not work with the preprocessed build
     if (movi_options->is_preprocessed()) {
@@ -866,40 +867,45 @@ void MoveStructure::build() {
             }
 #if MODE == 3 or MODE == 5 or MODE == 6 or MODE == 7
             // The first row is already set and accounted for, so we skip
-            if (movi_options->is_thresholds() and bwt_curr_length > 0 and bits[bwt_curr_length] == 1) {
-                // The bit was already set by one of the threshold values
-                // So, we have found a new run, and reest the run length
-                r += 1;
-                run_length = 0;
-                if (current_char != bwt_string[bwt_curr_length - 1]) {
-                    original_r += 1;
-                }
-            } else if (run_length == MAX_RUN_LENGTH) {
-                if (!(bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]))
-                    split_by_max_run += 1;
-                r += 1;
-                run_length = 0;
-                bits[bwt_curr_length] = 1;
-                if (current_char != bwt_string[bwt_curr_length - 1]) {
-                    original_r += 1;
-                }
-            } else if (bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]) {
+            if (bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]) {
+                // 1) A new run is detected if the next character is different
                 original_r += 1;
                 r += 1;
                 run_length = 0;
+                bits[bwt_curr_length] = 1;
+            } else if (movi_options->is_thresholds() and bwt_curr_length > 0 and bits[bwt_curr_length] == 1) {
+                // 2) A new run is detected if there is a non-trivial threshold at the next offset
+                // The bit was already set by one of the threshold values
+                // So, we have found a new run, and reset the run length
+                r += 1;
+                run_length = 0;
+                split_by_thresholds += 1;
+            } else if (run_length == MAX_RUN_LENGTH) {
+                // 3) A new run is detected if the length of the run is greater than MAX_RUN_LENGTH
+                r += 1;
+                run_length = 0;
+                split_by_max_run += 1;
                 bits[bwt_curr_length] = 1;
             }
 #endif
 #if MODE == 0 or MODE == 1 or MODE == 4
             if (bwt_curr_length > 0 && current_char != bwt_string[bwt_curr_length - 1]) {
+                // 1) A new run is detected if the next character is different
                 original_r += 1;
                 r += 1;
                 run_length = 0;
+                if (splitting and !bits[bwt_curr_length]) {
+                    std::cerr << "There is something wrong with the splitting vector.\n";
+                    std::cerr << "The run boundaries should have been set to 1 since a new character was detected.\n";
+                    exit(0);
+                }
                 bits[bwt_curr_length] = 1;
             } else if (splitting && bwt_curr_length > 0 && bits[bwt_curr_length]) {
+                // 2) A new run is detected based on Nishimoto-Tabei splitting
                 r += 1;
                 run_length = 0;
             } else if (run_length == MAX_RUN_LENGTH) {
+                // 3) A new run is detected if the length of the run is greater than MAX_RUN_LENGTH
                 split_by_max_run += 1;
                 r += 1;
                 run_length = 0;
@@ -918,8 +924,7 @@ void MoveStructure::build() {
 //         if (!splitting) r = original_r;
 // #endif
         length = bwt_curr_length; // bwt_string.length();
-        std::cerr << "\nsplit_by_max_run: " << split_by_max_run << "\n";
-        std::cerr << "length: " << length << "\n";
+        std::cerr << "\n";
 
         // Building the auxilary structures
         uint64_t alphabet_index = 0;
@@ -963,8 +968,11 @@ void MoveStructure::build() {
         std::cerr << "\nAll the Occ bit vectors are built.\n";
     }
 
+
+    std::cerr << "\nsplit_by_max_run: " << split_by_max_run << "\n";
+    std::cerr << "split_by_thresholds: " << split_by_thresholds << "\n";
     std::cerr << "length: " << length << "\n";
-    std::cerr << "\n\nr: " << r << "\n";
+    std::cerr << "r: " << r << "\n";
     std::cerr << "original_r: " << original_r << "\n";
     rlbwt.resize(r);
 

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -968,7 +968,6 @@ void MoveStructure::build() {
         std::cerr << "\nAll the Occ bit vectors are built.\n";
     }
 
-
     std::cerr << "\nsplit_by_max_run: " << split_by_max_run << "\n";
     std::cerr << "split_by_thresholds: " << split_by_thresholds << "\n";
     std::cerr << "length: " << length << "\n";

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -37,6 +37,9 @@ std::string program() {
 #if MODE == 6
     return "compact-thresholds";
 #endif
+#if MODE == 7
+    return "tally-thresholds";
+#endif
 }
 
 kseq_t* open_kseq(gzFile& fp, std::string file_address) {
@@ -160,7 +163,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
                     if (result.count("thresholds")) {
                         movi_options.set_thresholds(true);
                     }
-#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6
+#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6 or MODE == 7
                     // In these modes, thresholds are always stored
                     movi_options.set_thresholds(true);
 #endif

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -298,7 +298,12 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
     if (!movi_options.no_prefetch()) {
         ReadProcessor rp(movi_options.get_read_file(), mv_, movi_options.get_strands(), movi_options.is_verbose(), movi_options.is_reverse());
         if (movi_options.is_pml() or movi_options.is_zml() or movi_options.is_count()) {
+#if MODE == 5 or MODE == 7
+            rp.process_latency_hiding_tally();
+#endif
+#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 3 or MODE == 6
             rp.process_latency_hiding();
+#endif
         } else if (movi_options.is_kmer()) {
             rp.kmer_search_latency_hiding(movi_options.get_k());
         }

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -420,8 +420,7 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
             }
             std::cerr << "The count file is closed.\n";
         } else if (movi_options.is_kmer()) {
-            std::cout << "\n\nNumber of kmers found in the index: " << mv_.kmer_stats.positive_kmers << "\n\n\n";
-            mv_.kmer_stats.print();
+            mv_.kmer_stats.print(movi_options.is_kmer_count());
         }
 
         if (movi_options.is_logs()) {

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -33,6 +33,7 @@ std::string program() {
 #endif
 #if MODE == 5
     return "tally";
+#endif
 #if MODE == 6
     return "compact-thresholds";
 #endif

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -26,7 +26,7 @@ std::string program() {
     return "constant";
 #endif
 #if MODE == 3
-    return "compact";
+    return "blocked";
 #endif
 #if MODE == 4
     return "split";
@@ -35,7 +35,7 @@ std::string program() {
     return "tally";
 #endif
 #if MODE == 6
-    return "compact-thresholds";
+    return "blocked-thresholds";
 #endif
 #if MODE == 7
     return "tally-thresholds";

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -31,6 +31,9 @@ std::string program() {
 #if MODE == 4
     return "split";
 #endif
+#if MODE == 5
+    return "tally";
+#endif
 }
 
 kseq_t* open_kseq(gzFile& fp, std::string file_address) {

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -82,6 +82,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         ("preprocessed", "The BWT is preprocessed into heads and lens files")
         ("verify", "Verify if all the LF_move operations are correct")
         ("ftab-k", "The length of the ftab kmer", cxxopts::value<uint32_t>())
+        ("tally", "Sample id at every tally runs", cxxopts::value<uint32_t>())
         ("multi-ftab", "Use ftabs with smaller k values if the largest one fails");
 
     auto queryOptions = options.add_options("query")
@@ -163,6 +164,11 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
                     if (result.count("thresholds")) {
                         movi_options.set_thresholds(true);
                     }
+#if MODE == 5 or MODE == 7
+                    if (result.count("tally") >= 1) {
+                        movi_options.set_tally_checkpoints(static_cast<uint32_t>(result["tally"].as<uint32_t>()));
+                    }
+#endif
 #if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6 or MODE == 7
                     // In these modes, thresholds are always stored
                     movi_options.set_thresholds(true);

--- a/src/read_processor.cpp
+++ b/src/read_processor.cpp
@@ -119,7 +119,7 @@ void ReadProcessor::process_char(Strand& process) {
 #if MODE == 0 or MODE == 1 or MODE == 2 or MODE == 4
         bool up = mv.jump_thresholds(process.idx, process.offset, R[process.pos_on_r], process.scan_count);
 #endif
-#if MODE == 3
+#if MODE == 3 or MODE == 5
         bool up = mv.jump_randomly(process.idx, R[process.pos_on_r], process.scan_count);
 #endif
         process.match_len = 0;

--- a/src/read_processor.cpp
+++ b/src/read_processor.cpp
@@ -1,4 +1,5 @@
 #include "read_processor.hpp"
+#include <cpuid.h>
 
 uint32_t alphamap_3_[4][4] = {{3, 0, 1, 2},
                              {0, 3, 1, 2},
@@ -6,6 +7,12 @@ uint32_t alphamap_3_[4][4] = {{3, 0, 1, 2},
                              {0, 1, 2, 3}};
 
 ReadProcessor::ReadProcessor(std::string reads_file_name, MoveStructure& mv_, int strands_ = 4, bool verbose_ = false, bool reverse_ = false) : mv(mv_) {
+
+    int cpu_info[4];
+    __cpuid(0x80000006, cpu_info[0], cpu_info[1], cpu_info[2], cpu_info[3]);
+    cache_line_size = (cpu_info[2] & 0xFF);
+    prefetch_step = cache_line_size/sizeof(MoveRow) - 1;
+
     verbose = verbose_;
     reverse = mv_.movi_options->is_reverse();
     // Solution for handling the stdin input: https://biowize.wordpress.com/2013/03/05/using-kseq-h-with-stdin/
@@ -76,6 +83,20 @@ void ReadProcessor::reset_process(Strand& process) {
         process.pos_on_r = process.read.length() - 1;
         process.idx = mv.r - 1;
         process.offset = mv.get_n(process.idx) - 1;
+
+#if MODE == 5 or MODE == 7
+        // This is necessary
+        process.tally_state = false;
+        // These shouldn't matter
+        process.id_found = true;
+        process.tally_b = 0;
+        process.rows_until_tally = 0;
+        process.next_check_point = 0;
+        process.run_id = 0;
+        process.last_id = 0;
+        process.char_index = 0;
+        process.tally_offset = 0;
+#endif
     }
 }
 
@@ -146,6 +167,213 @@ void ReadProcessor::process_char(Strand& process) {
     // uint64_t ff_count = mv.LF_move(process.offset, process.idx);
     // process.ff_count_tot += ff_count;
 }
+
+#if MODE == 5 or MODE == 7
+void ReadProcessor::process_char_tally(Strand& process) {
+    if (process.tally_state == false) {
+
+        if (process.pos_on_r < process.read.length() - 1) {
+
+            // First find the id if not found already
+            if (process.id_found == false) {
+                find_next_id(process);
+            }
+
+            // LF step
+            process.ff_count = mv.LF_move(process.offset, process.idx, process.run_id);
+        }
+
+        // After LF is performed, calculate PML based on case1/case2
+        auto& row = mv.rlbwt[process.idx];
+        uint64_t row_idx = process.idx;
+        char row_c = mv.alphabet[row.get_c()];
+        std::string& R = process.mq.query();
+        process.scan_count = 0;
+        if (mv.alphamap[static_cast<uint64_t>(R[process.pos_on_r])] == mv.alphamap.size()) {
+            process.match_len = 0;
+        } else if (row_c == R[process.pos_on_r]) {
+            // Case 1
+            process.match_len += 1;
+        } else {
+            // Case 2
+            // Jumping up or down (randomly or with thresholds)
+            uint64_t idx_before_jump = process.idx;
+            bool up = false;
+#if MODE == 7
+            up = mv.jump_thresholds(process.idx, process.offset, R[process.pos_on_r], process.scan_count);
+#endif
+#if MODE == 5
+            up = mv.jump_randomly(process.idx, R[process.pos_on_r], process.scan_count);
+#endif
+            process.match_len = 0;
+            char c = mv.alphabet[mv.rlbwt[process.idx].get_c()];
+            // sanity check
+            if (c == R[process.pos_on_r]) {
+                // Observing a match after the jump
+                // The right match_len should be:
+                // min(new_lcp, match_len + 1)
+                // But we cannot compute lcp here
+                process.offset = up ? mv.get_n(process.idx) - 1 : 0;
+                if (verbose)
+                    std::cerr << "\t idx: " << process.idx << " offset: " << process.offset << "\n";
+            } else {
+                std::cerr << "\t \t This should not happen!\n";
+            }
+        }
+        process.mq.add_ml(process.match_len);
+        process.pos_on_r -= 1;
+
+        // get_id is called at the beginning of the next LF
+        // Now we should find out what is the next tally_b to prefetch it
+        // Set tally_state to true, so that the other branch for id computation is called
+        process.id_found = false;
+        find_tally_b(process);
+    } else {
+        // The id for the run at the next_check_point
+        process.run_id = mv.tally_ids[process.char_index][process.tally_b].get();
+
+        count_rows_untill_tally(process);
+
+        // The id stored at the checkpoint is actually the id for the current run
+        // because there was no run with the same character between the current run and the next_check_point
+        if (process.last_id == process.idx and mv.get_char(process.idx) != mv.get_char(process.next_check_point)) {
+            // process.run_id is already set to the correct value above
+            // process.run_id = mv.tally_ids[process.char_index][process.tally_b].get();
+
+            process.id_found = true;
+        }
+
+        process.tally_state = false;
+    }
+}
+
+void ReadProcessor::find_next_id(Strand& process) {
+
+    // Sanity check, the offset in the destination run should be always smaller than the length of that run
+    if (process.tally_offset >= mv.get_n(process.run_id)) {
+        std::cout << "tally_offset: " << process.tally_offset << " n: " << mv.get_n(process.run_id) << "\n"; // << dbg.str() << "\n";
+        exit(0);
+    }
+
+    if (process.tally_offset >= process.rows_until_tally) {
+        process.id_found = true;
+        return;
+    } else {
+        process.rows_until_tally -= (process.tally_offset + 1);
+        process.run_id -= 1;
+    }
+
+    while (process.rows_until_tally != 0) {
+        if (process.rows_until_tally >= mv.get_n(process.run_id)) {
+            process.rows_until_tally -= mv.get_n(process.run_id);
+            process.run_id -= 1;
+        } else {
+            process.rows_until_tally = 0;
+        }
+    }
+
+    process.id_found = true;
+}
+
+void ReadProcessor::count_rows_untill_tally(Strand& process) {
+
+    process.rows_until_tally = 0;
+
+    // // The id for the run at the next_check_point
+    // process.run_id = mv.tally_ids[process.char_index][process.tally_b].get();
+
+    uint64_t last_count = 0;
+    process.last_id = mv.r;
+
+    // Look for the rows between idx and the next_check_point
+    // Count how many rows with the same character exists between
+    // the current run head and the next run head for which we know the id
+    // dbg << "from: " << idx << " to: " << next_check_point << "\n";
+    for (uint64_t i = process.idx; i < process.next_check_point; i++) {
+        // Only count the rows with the same character
+        if (mv.get_char(i) == mv.get_char(process.idx)) {
+            process.rows_until_tally += mv.get_n(i);
+            process.last_id = i;
+        }
+    }
+
+    // // The id stored at the checkpoint is actually the id for the current run
+    // // because there was no run with the same character between the current run and the next_check_point
+    // if (last_id == process.idx and mv.get_char(process.idx) != mv.get_char(process.next_check_point)) {
+    //     // process.run_id is already set to the correct value above
+    //     // process.run_id = mv.tally_ids[process.char_index][process.tally_b].get();
+
+    //     process.tally_state = false;
+    //     return;
+    // }
+
+    if (process.last_id == mv.r) {
+        std::cerr << "last_id should never be equal to r.\n";
+        exit(0);
+    }
+
+    // We should know what will be the offset of the run head in the destination run (id)
+    process.tally_offset = mv.get_offset(process.next_check_point);
+
+    // At the checkpoint, one id is stored for each character
+    // For the character of the checkpoint, the id of the checkpoint is stored
+    // For other characters, the id of the last run before the checkpoint with that character is stored
+    // So, we have to decrease the number of rows of the last run as they are not between the current run
+    // and the run for which we know the id
+    // Also, for other characters, offset should be stored based on that run (not the checkpoint run)
+    if (mv.get_char(process.idx) != mv.get_char(process.next_check_point)) {
+        process.rows_until_tally -= mv.get_n(process.last_id);
+        process.tally_offset = mv.get_offset(process.last_id);
+    }
+}
+
+void ReadProcessor::find_tally_b(Strand& process) {
+    uint64_t id = 0;
+
+    // The $ always goes to row/run 0
+    if (process.idx == mv.end_bwt_idx) {
+        process.run_id = 0;
+
+        process.tally_state = false;
+        process.id_found = true;
+        return;
+    }
+
+    process.char_index = mv.rlbwt[process.idx].get_c();
+
+    // The id of the last run is always stored at the last tally_id row
+    if (process.idx == mv.r - 1) {
+        uint64_t tally_ids_len = mv.tally_ids[process.char_index].size();
+        process.run_id = mv.tally_ids[process.char_index][tally_ids_len - 1].get();
+
+        process.tally_state = false;
+        process.id_found = true;
+        return;
+    }
+
+    uint64_t tally_a = process.idx / mv.tally_checkpoints;
+
+    // If we are at a checkpoint, simply return the stored id
+    if (process.idx % mv.tally_checkpoints == 0) {
+        process.run_id = mv.tally_ids[process.char_index][tally_a].get();
+
+        process.tally_state = false;
+        process.id_found = true;
+        return;
+    }
+
+    // find the next check point
+    process.tally_b = tally_a + 1;
+
+    process.next_check_point = process.tally_b * mv.tally_checkpoints;
+    // If we are at the end, just look at the last run
+    if (process.tally_b * mv.tally_checkpoints >= mv.r) {
+        process.next_check_point = mv.r - 1;
+    }
+
+    process.tally_state = true;
+}
+#endif
 
 void ReadProcessor::write_mls(Strand& process) {
     bool write_stdout = mv.movi_options->is_stdout();
@@ -314,6 +542,48 @@ void ReadProcessor::process_latency_hiding() {
         fastforwards_file.close();
     }
 }
+
+#if MODE == 5 or MODE == 7
+void ReadProcessor::process_latency_hiding_tally() {
+    bool is_pml = mv.movi_options->is_pml();
+
+    std::vector<Strand> processes;
+    uint64_t finished_count = initialize_strands(processes);
+    std::cerr << strands << " processes are initiated.\n";
+
+    while (finished_count != strands) {
+        for (uint64_t i = 0; i < strands; i++) {
+            if (!processes[i].finished) {
+                if (is_pml) {
+                    process_char_tally(processes[i]);
+                }
+                // 2: if the read is done -> Write the pmls and go to next read
+                if (is_pml and processes[i].pos_on_r <= -1) {
+                    write_mls(processes[i]);
+                    reset_process(processes[i]);
+                }
+                // 3: -- check if it was the last read in the file -> finished_count++
+                if (processes[i].finished) {
+                    finished_count += 1;
+                } else {
+                    // 4: prefetching
+                    if (processes[i].tally_state) {
+                        // prefetch tally
+                        my_prefetch_r((void*)(&(mv.tally_ids[processes[i].char_index][0]) + processes[i].tally_b));
+                        // prefetch following rows until the checkpoint
+                        for (uint64_t tally = processes[i].idx; tally <= processes[i].next_check_point; tally += prefetch_step) // Every prefetch loads 64 bytes which is about 20 move rows
+                            my_prefetch_r((void*)(&(mv.rlbwt[0]) + tally));
+                    } else {
+                        // prefetch tally.id
+                        for (uint64_t tally = 0; tally <= mv.tally_checkpoints; tally += prefetch_step)
+                            my_prefetch_r((void*)(&(mv.rlbwt[0]) + processes[i].run_id + tally));
+                    }
+                }
+            }
+        }
+    }
+}
+#endif
 
 /* void ReadProcessor::ziv_merhav_latency_hiding() {
     std::vector<Strand> processes;

--- a/src/read_processor.cpp
+++ b/src/read_processor.cpp
@@ -117,7 +117,7 @@ void ReadProcessor::process_char(Strand& process) {
         // Jumping up or down (randomly or with thresholds)
         uint64_t idx_before_jump = process.idx;
         bool up = false;
-#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6
+#if MODE == 0 or MODE == 1 or MODE == 4 or MODE == 6 or MODE == 7
         up = mv.jump_thresholds(process.idx, process.offset, R[process.pos_on_r], process.scan_count);
 #endif
 #if MODE == 3 or MODE == 5

--- a/src/sequitur.cpp
+++ b/src/sequitur.cpp
@@ -335,7 +335,7 @@ void MoveStructure::query_all_kmers(MoveQuery& mq, bool kmer_counts) {
         } else {
             if (kmer_counts) {
                 if (pos_on_r <= 2*k) {
-                    kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
+                    kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r, true);
                     // kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);
                 } else {
                     kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);

--- a/src/sequitur.cpp
+++ b/src/sequitur.cpp
@@ -1,0 +1,323 @@
+#include <sys/stat.h> 
+
+#include "move_structure.hpp"
+#include "utils.hpp"
+
+std::ostringstream dbg;
+
+// pos_on_r points to the furthest base of the kmer to be searched
+// The search is from the right end of the kmer
+// All kmers on the right side of the kmer_middle might be found in this call if they exist
+uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& pos_on_r) {
+    uint64_t kmers_found = 0;
+    int32_t last_kmer_looked_at = pos_on_r;
+
+    size_t ftab_k = movi_options->get_ftab_k();
+    size_t k = movi_options->get_k();
+    auto& query_seq = mq.query();
+
+    // The middle point of the kmer
+    int32_t kmer_middle = pos_on_r - k/2;
+    // To remember the kmer which initiated the search
+    int32_t pos_on_r_saved = pos_on_r;
+    // The number of bases matched so far
+    uint64_t match_len = 0;
+    // The position of the left side of the kmer on the read
+    int32_t kmer_left = pos_on_r - k + 1;
+    // The position on the right side of the match to be found by ftab
+    int32_t ftab_right = kmer_left + ftab_k - 1;
+
+    // At the time, the initialization works if ftab with ftab_k exists only
+    // And the multi-ftab strategy must be turned off
+    movi_options->set_multi_ftab(false);
+
+    MoveBiInterval bi_interval;
+    int32_t ftab_right_initialize = ftab_right;
+
+    bi_interval = initialize_bidirectional_search(mq, ftab_right_initialize, match_len);
+
+    if (match_len == 0 and ftab_k > 1) {
+        // If the ftab-k-mer at the end of the read is not found,
+        // we can skip all the kmers until ftab_right - 1
+        kmer_stats.initialize_skipped += 1;
+        pos_on_r = ftab_right - 1;
+        return 0;
+    }
+
+    // pos_on_r and pos_on_r_saved point to the beginning of the kmer for which the bidirectional initialization was performed above
+    // Extend to right until the kmer is found and save the observed intervals beyond k/2
+    std::vector<MoveBiInterval> partial_matches;
+    partial_matches.resize(k);
+    // kmer_right is the last position matched so far
+    uint64_t kmer_right = ftab_right;
+    int here = 0;
+    while (kmer_right < pos_on_r_saved) {
+        // The next k-mer we are looking at, ends at next_pos
+        int next_pos = kmer_right + 1;
+
+        if (movi_options->is_debug() and next_pos >= k)
+            dbg << "\nkmer at " << next_pos << ": " << query_seq.substr(next_pos - k + 1, k) << " ";
+
+        bool extend_right_res = extend_right(query_seq[next_pos], bi_interval);
+        if (!extend_right_res) {
+            here = 1;
+            // The kmer was not found, we can skip kmers until ftab_right
+            pos_on_r = kmer_right;
+            last_kmer_looked_at = next_pos;
+
+            // Printing all the kmers being skipped, because the extension to the right was not possible
+            if (movi_options->is_debug()) {
+                int j = next_pos + 1;
+                while (j < pos_on_r_saved) {
+                    if (j > k)
+                        dbg << "\nkmer at " << j << ": " << query_seq.substr(j - k + 1, k) << "-";
+                    j += 1;
+                }
+            }
+
+            // It's important to break here, to avoid false extensions in the following iterations
+            break;
+        } else {
+            match_len += 1;
+            kmer_right = next_pos;
+            bi_interval.match_len = match_len;
+            // store the intervals for matches beyond half point of the kmer
+            if (kmer_right > kmer_middle and kmer_right != pos_on_r) {
+                bi_interval.match_len = match_len;
+                // "kmer_right - kmer_left" is the index of the kmer from the left end
+                partial_matches[kmer_right - kmer_left] = bi_interval;
+            }
+        }
+    }
+
+    if (kmer_right == pos_on_r_saved) {
+        // The kmer at pos_on_r was found by k bidirectional backward search
+        kmers_found += 1;
+        kmer_stats.backward_search_empty += 1;
+        // std::cerr << "The first kmer at " << pos_on_r << " was found.\n";
+        pos_on_r = pos_on_r_saved - 1;
+        // To avoid searching this kmer again in the next step
+        kmer_right -= 1;
+
+        if (movi_options->is_debug()) {
+            if (pos_on_r_saved > k)
+                dbg << "\nkmer at " << pos_on_r_saved << ": " << query_seq.substr(pos_on_r_saved - k + 1, k) << "\n";
+            dbg << "1";
+        }
+
+    } else {
+        if (movi_options->is_debug()) {
+            if (pos_on_r_saved > k)
+                dbg << "\nkmer at " << pos_on_r_saved << ": " << query_seq.substr(pos_on_r_saved - k + 1, k) << "-\n";
+            dbg << "0";
+        }
+    }
+
+
+    // Use partial matches for finding other overlapping kmers (until half point)
+    if (kmer_right > kmer_middle) {
+        if (movi_options->is_debug()) {
+            for (int i = kmer_right + 1; i < pos_on_r_saved; i++) {
+                dbg << "0";
+            }
+        }
+        for (uint i = kmer_right; i > kmer_middle; i--) {
+            // Set kmer_left_ext to be the last match position on the left end
+            int32_t kmer_left_ext = kmer_left;
+            auto& partial_match_interval = partial_matches[i - kmer_left];
+            last_kmer_looked_at = i;
+            while (partial_match_interval.match_len < k and kmer_left_ext > 0) {
+                // We don't need to do bidirectional left extension here, simple backward search is enough
+                bool res = backward_search_step(query_seq[kmer_left_ext - 1], partial_match_interval.fw_interval);
+                // bool res = extend_left(query_seq[kmer_left_ext - 1], partial_match_interval);
+                if (!res) {
+                    // The current kmer is not present, move to the next partial match by breaking from the inner loop
+                    break;
+                } else {
+                    kmer_left_ext -= 1;
+                    partial_match_interval.match_len += 1;
+                }
+            }
+            if (partial_match_interval.match_len >= k) {
+                // The kmer was found by extending the partial match to left
+                kmers_found += 1;
+                kmer_stats.positive_skipped += 1;
+                if (movi_options->is_debug()) {
+                    std::cerr << "kmer at " << kmer_left_ext + k - 1 << " was found.\n";
+                    dbg << "1";
+                }
+            } else {
+                if (movi_options->is_debug()) {
+                    dbg << "0";
+                }
+            }
+
+            pos_on_r -= 1;
+        }
+        // At this point we have checked the presence of all the kmer beyond kmer_middle
+    } else {
+        // If we got here, we had to start the first while by breaking because of an unsuccessfull attempt to extend to the right
+        if (here != 1)
+            std::cerr << here << "\t" << last_kmer_looked_at << "\t" << pos_on_r << "\n";
+        if (kmer_right != pos_on_r)
+            std::cerr << "This should not happen: " << kmer_right << "\t" << pos_on_r << "\n";
+        // pos_on_r should have already been assigned to be the last kmer_right
+        // So we should never get here to do the assignment in practice
+        pos_on_r = kmer_right;
+
+        if (movi_options->is_debug()) {
+            for (int i = kmer_middle + 1; i <= pos_on_r_saved - 1; i++) {
+                dbg << "0";
+            }
+        }
+
+    }
+    return kmers_found;
+}
+
+uint64_t MoveStructure::query_kmers_from(MoveQuery& mq, int32_t& pos_on_r, bool single) {
+    size_t ftab_k = movi_options->get_ftab_k();
+    size_t k = movi_options->get_k();
+    auto& query_seq = mq.query();
+    int32_t pos_on_r_saved = pos_on_r;
+
+    // An alternative strategy to look ahead for possible skipping
+    // int32_t step = 0;
+    // if (ftab_k > 1 and !look_ahead_ftab(mq, pos_on_r, step)) {
+    //     kmer_stats.look_ahead_skipped += k - ftab_k - step;
+    //     pos_on_r = pos_on_r - k + ftab_k + step - 1;
+    //     pos_on_r_saved = pos_on_r;
+    // }
+
+    uint64_t match_len = 0;
+    MoveInterval initial_interval;
+    do {
+        initial_interval = initialize_backward_search(mq, pos_on_r, match_len);
+        if (match_len == 0 and ftab_k > 1) {
+            kmer_stats.initialize_skipped += 1;
+            pos_on_r -= 1;
+            pos_on_r_saved = pos_on_r;
+        }
+    } while (match_len == 0 and pos_on_r >= k - 1 and ftab_k > 1);
+
+    // I want to check how much slower it gets if turn off the positive skip:
+    auto backward_search_result = backward_search(query_seq, pos_on_r, initial_interval, single ? k - match_len - 2 : std::numeric_limits<int32_t>::max());
+
+    if (backward_search_result.is_empty()) {
+        // We get here when there is an illegal character at pos_on_r, just skip the current position
+        pos_on_r = pos_on_r_saved - 1;
+        kmer_stats.backward_search_empty += 1;
+        return 0;
+    } else {
+        if (pos_on_r_saved - pos_on_r >= k - 1) {
+            // At leat one kmer was found, update the postion and return the count
+            uint64_t kmers_found = pos_on_r_saved - pos_on_r - k + 2;
+            kmer_stats.positive_skipped += kmers_found - 1;
+
+            if (movi_options->is_debug()) {
+                int32_t pos_on_r_ = pos_on_r_saved;
+                auto backward_search_result_one_extra_base = backward_search(query_seq, pos_on_r_, initial_interval, k - match_len - 1);
+                dbg << backward_search_result.count(rlbwt) << "----" <<  backward_search_result_one_extra_base.count(rlbwt) << "\n";
+                dbg << backward_search_result << "\n";
+                if (backward_search_result.count(rlbwt) == backward_search_result_one_extra_base.count(rlbwt)) {
+                    // TODO: Use a counter to count the number of such incidents
+                } else {
+                }
+            }
+
+            pos_on_r = pos_on_r + k - 2;
+	        return kmers_found;
+        } else {
+            // No kmer was found, update the postion
+            kmer_stats.backward_search_failed += 1;
+            pos_on_r = pos_on_r_saved - 1;
+            return 0;
+        }
+    }
+}
+
+void MoveStructure::query_all_kmers(MoveQuery& mq, bool kmer_counts) {
+    size_t ftab_k = movi_options->get_ftab_k();
+    size_t k = movi_options->get_k();
+    auto& query_seq = mq.query();
+    int32_t pos_on_r = query_seq.length() - 1;
+
+    // To handle a special case for k equal to 1
+    if (k == 1) {
+        uint64_t kmers_found = 0;
+        while (pos_on_r >= 0) {
+            kmers_found += check_alphabet(query_seq[pos_on_r]) ? 1 : 0;
+            pos_on_r -= 1;
+        }
+        kmer_stats.positive_kmers += kmers_found;
+        return;
+    }
+
+    while (!check_alphabet(query_seq[pos_on_r])) {
+        pos_on_r -= 1; // Find the first position where the character is legal
+    }
+
+
+    int32_t step = k/3;
+    // k - step has to be always greater than ftab-k
+    if (k - step < ftab_k) {
+        step = k - ftab_k - 1;
+    }
+
+    while (pos_on_r >= k - 1) {
+        if (pos_on_r >= k -1 + step and !look_ahead_backward_search(mq, pos_on_r, step)) {
+            kmer_stats.look_ahead_skipped += step + 1;
+            pos_on_r = pos_on_r - step - 1;
+        } else {
+            if (kmer_counts) {
+                if (pos_on_r == k - 1) {
+                    kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
+                } else {
+                    kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);
+
+                    if (movi_options->is_debug()) {
+                        dbg.str("");
+                        dbg.clear();
+                        int pos_on_r_before = pos_on_r;
+                        int found_regular = 0;
+                        dbg << "regular backward search:\n";
+                        int k_m = pos_on_r - k/2;
+                        dbg << pos_on_r << "\t" << k_m << "\n";
+                        dbg << k/2 << "\n";
+                        for (int j = pos_on_r; j > k_m; j--) {
+                            dbg << " " << j << " ";
+                            if (j >= k)
+                                dbg << "\nkmer at " << j << ": " << query_seq.substr(j - k + 1, k) << " ";
+
+                            int pos = j;
+                            dbg << " pos:" << pos << " ";
+                            int z = query_kmers_from(mq, pos, true);
+                            if (z == 1 and pos == j - 1) {
+                                dbg << "1";
+                                found_regular += 1;
+                            } else
+                                dbg << "0";
+                        }
+                        dbg << "\n";
+                        dbg << "bidirectional search:\n";
+                        int pos = pos_on_r_before;
+                        int found_bidirectional = query_kmers_from_bidirectional(mq, pos);
+                        dbg << "\n";
+                        kmer_stats.positive_kmers += found_bidirectional;
+                        if (found_regular != found_bidirectional) {
+                            std::cerr << "pos_on_r_before:" << pos_on_r_before << " pos_on_r:" << pos_on_r
+                                    << " found_regular:" << found_regular << " found_bidirectional" << found_bidirectional << "\n";
+                            std::cerr << dbg.str() << std::endl;
+                        }
+                    }
+                }
+            } else {
+                kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
+            }
+        }
+
+        while (!check_alphabet(query_seq[pos_on_r])) {
+            pos_on_r -= 1; // Find the first position where the character is legal
+        }
+    }
+}

--- a/src/sequitur.cpp
+++ b/src/sequitur.cpp
@@ -5,10 +5,14 @@
 
 std::ostringstream dbg;
 
-// pos_on_r points to the furthest base of the kmer to be searched
+// IMPORTANT: The index has to be built on a reference with separators to get the correct kmer counts
+// IMPORTANT: For the bidirectional search, also the index has to be built with the separators
+
+// pos_on_r points to the furthest (to the right) base of the kmer to be searched
 // The search is from the right end of the kmer
 // All kmers on the right side of the kmer_middle might be found in this call if they exist
 uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& pos_on_r) {
+
     uint64_t kmers_found = 0;
     int32_t last_kmer_looked_at = pos_on_r;
 
@@ -16,8 +20,6 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
     size_t k = movi_options->get_k();
     auto& query_seq = mq.query();
 
-    // The middle point of the kmer
-    int32_t kmer_middle = pos_on_r - k/2;
     // To remember the kmer which initiated the search
     int32_t pos_on_r_saved = pos_on_r;
     // The number of bases matched so far
@@ -39,18 +41,35 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
     if (match_len == 0 and ftab_k > 1) {
         // If the ftab-k-mer at the end of the read is not found,
         // we can skip all the kmers until ftab_right - 1
-        kmer_stats.initialize_skipped += 1;
+        kmer_stats.initialize_skipped += (pos_on_r - ftab_right + 1);
         pos_on_r = ftab_right - 1;
         return 0;
     }
 
+    if (ftab_right_initialize != kmer_left) {
+        // Sanity check: to make sure ftab and initialization is working
+        std::cerr << "ftab_right_initialize is now updated and should have been equal to kmer_left.\n";
+        std::cerr << "ftab_right: " << ftab_right
+                  << "\tftab_right_initialize:" << ftab_right_initialize
+                  << "\tkmer_left:" << kmer_left << "\n";
+        exit(0);
+    }
+
     // pos_on_r and pos_on_r_saved point to the beginning of the kmer for which the bidirectional initialization was performed above
     // Extend to right until the kmer is found and save the observed intervals beyond k/2
+    // The middle point of the kmer
+    int32_t partial_count = k/2;
+    int32_t non_extension_count = k - partial_count;
+    int32_t kmer_middle = pos_on_r_saved - partial_count;
     std::vector<MoveBiInterval> partial_matches;
-    partial_matches.resize(k);
+    if (partial_count > 0) {
+        partial_matches.resize(partial_count - 1); // -1 is because the last kmer is the one found by bidirectional
+    }
+    int32_t partial_saved_count = 0;
+
     // kmer_right is the last position matched so far
     uint64_t kmer_right = ftab_right;
-    int here = 0;
+
     while (kmer_right < pos_on_r_saved) {
         // The next k-mer we are looking at, ends at next_pos
         int next_pos = kmer_right + 1;
@@ -59,9 +78,10 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
             dbg << "\nkmer at " << next_pos << ": " << query_seq.substr(next_pos - k + 1, k) << " ";
 
         bool extend_right_res = extend_right(query_seq[next_pos], bi_interval);
+
         if (!extend_right_res) {
-            here = 1;
-            // The kmer was not found, we can skip kmers until ftab_right
+            // The kmer was not found, we can skip kmers until kmer_right
+            kmer_stats.right_extension_failed += pos_on_r_saved - kmer_right; // b += pos_on_r_saved - kmer_right;
             pos_on_r = kmer_right;
             last_kmer_looked_at = next_pos;
 
@@ -79,32 +99,58 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
             break;
         } else {
             match_len += 1;
-            kmer_right = next_pos;
-            bi_interval.match_len = match_len;
+            kmer_right = next_pos; // increaments kmer_right one position to the right
+
+            // pos_on_r always points to the right end of the right most kmer
+            pos_on_r = kmer_right;
+
+            if (match_len != bi_interval.match_len) {
+                // Sanity check: to make sure match_len is computed correctly
+                std::cerr << "The interval's match_len is not set correctly.\n";
+                std::cerr << bi_interval.match_len << " " << match_len << "\n";
+                exit(0);
+            }
+
             // store the intervals for matches beyond half point of the kmer
-            if (kmer_right > kmer_middle and kmer_right != pos_on_r) {
-                bi_interval.match_len = match_len;
-                // "kmer_right - kmer_left" is the index of the kmer from the left end
-                partial_matches[kmer_right - kmer_left] = bi_interval;
+            if (kmer_right > kmer_middle and kmer_right != pos_on_r_saved) {
+
+                if (bi_interval.match_len - non_extension_count - 1 >= partial_matches.size()) {
+                    std::cerr << bi_interval.match_len - partial_count - 1 << "\t" << partial_matches.size() << "\n";
+                    std::cerr << kmer_middle << "\t" << kmer_right << "\t" << pos_on_r_saved << "\n";
+                    exit(0);
+                }
+
+                if (partial_saved_count != bi_interval.match_len - non_extension_count - 1) {
+                    // Sanity check
+                    std::cerr << partial_saved_count << "\t" << "\n";
+                    exit(0);
+                }
+
+                partial_matches[bi_interval.match_len - non_extension_count - 1] = bi_interval;
+                partial_saved_count += 1;
             }
         }
     }
 
     if (kmer_right == pos_on_r_saved) {
         // The kmer at pos_on_r was found by k bidirectional backward search
-        kmers_found += 1;
-        kmer_stats.backward_search_empty += 1;
-        // std::cerr << "The first kmer at " << pos_on_r << " was found.\n";
-        pos_on_r = pos_on_r_saved - 1;
+        kmers_found += 1; // a += 1;
+
+        if (pos_on_r != pos_on_r_saved) {
+            // pos_on_r should be equal to pos_on_r_saved at this point
+            std::cerr << "pos_on_r: " << pos_on_r << "\tpos_on_r_saved" << pos_on_r_saved << "\n";
+            exit(0);
+        }
+
         // To avoid searching this kmer again in the next step
         kmer_right -= 1;
+        pos_on_r = kmer_right;
 
         if (movi_options->is_debug()) {
             if (pos_on_r_saved > k)
                 dbg << "\nkmer at " << pos_on_r_saved << ": " << query_seq.substr(pos_on_r_saved - k + 1, k) << "\n";
             dbg << "1";
         }
-
     } else {
         if (movi_options->is_debug()) {
             if (pos_on_r_saved > k)
@@ -121,11 +167,18 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
                 dbg << "0";
             }
         }
-        for (uint i = kmer_right; i > kmer_middle; i--) {
+
+        int skip_kmers = 0;
+        int partial_found = 0;
+
+        for (int i = 0; i < partial_saved_count; i += (skip_kmers + 1) ) {
             // Set kmer_left_ext to be the last match position on the left end
             int32_t kmer_left_ext = kmer_left;
-            auto& partial_match_interval = partial_matches[i - kmer_left];
-            last_kmer_looked_at = i;
+            auto& partial_match_interval = partial_matches[i];
+
+            kmer_right = kmer_middle + 1 + i;
+            last_kmer_looked_at = kmer_right; // not used
+
             while (partial_match_interval.match_len < k and kmer_left_ext > 0) {
                 // We don't need to do bidirectional left extension here, simple backward search is enough
                 bool res = backward_search_step(query_seq[kmer_left_ext - 1], partial_match_interval.fw_interval);
@@ -138,27 +191,38 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
                     partial_match_interval.match_len += 1;
                 }
             }
-            if (partial_match_interval.match_len >= k) {
+
+            // There is a possibility to a number of next kmers because of their overlap
+            skip_kmers = (partial_match_interval.match_len < k - 1) ? k - partial_match_interval.match_len - 1 : 0;
+
+            if (partial_match_interval.match_len == k) {
                 // The kmer was found by extending the partial match to left
                 kmers_found += 1;
-                kmer_stats.positive_skipped += 1;
+                partial_found += 1;
+
+                kmer_stats.positive_skipped += 1; // c += 1;
                 if (movi_options->is_debug()) {
                     std::cerr << "kmer at " << kmer_left_ext + k - 1 << " was found.\n";
                     dbg << "1";
                 }
             } else {
+                skip_kmers = 0;
+                kmer_stats.backward_search_failed += skip_kmers + 1; // d += skip_kmers + 1;
                 if (movi_options->is_debug()) {
                     dbg << "0";
                 }
             }
-
-            pos_on_r -= 1;
         }
-        // At this point we have checked the presence of all the kmer beyond kmer_middle
+
+        // To check the correct count of the total kmers
+        // if (a+b+c+d != 15) std::cerr << a << "\t" << b << "\t" << c << "\t" << d << "\t|" << partial_saved_count << "|\n";
+
+        // At this point all the kmers to the right of kmer_middle are checked using the partial matches
+        pos_on_r = kmer_middle;
+
     } else {
         // If we got here, we had to start the first while by breaking because of an unsuccessfull attempt to extend to the right
-        if (here != 1)
-            std::cerr << here << "\t" << last_kmer_looked_at << "\t" << pos_on_r << "\n";
+        // kmers_found = 0;
         if (kmer_right != pos_on_r)
             std::cerr << "This should not happen: " << kmer_right << "\t" << pos_on_r << "\n";
         // pos_on_r should have already been assigned to be the last kmer_right
@@ -270,8 +334,9 @@ void MoveStructure::query_all_kmers(MoveQuery& mq, bool kmer_counts) {
             pos_on_r = pos_on_r - step - 1;
         } else {
             if (kmer_counts) {
-                if (pos_on_r == k - 1) {
+                if (pos_on_r <= 2*k) {
                     kmer_stats.positive_kmers += query_kmers_from(mq, pos_on_r);
+                    // kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);
                 } else {
                     kmer_stats.positive_kmers += query_kmers_from_bidirectional(mq, pos_on_r);
 

--- a/src/sequitur.cpp
+++ b/src/sequitur.cpp
@@ -135,7 +135,7 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
     if (kmer_right == pos_on_r_saved) {
         // The kmer at pos_on_r was found by k bidirectional backward search
         kmers_found += 1; // a += 1;
-
+        kmer_stats.total_counts += bi_interval.fw_interval.count(rlbwt);
         if (pos_on_r != pos_on_r_saved) {
             // pos_on_r should be equal to pos_on_r_saved at this point
             std::cerr << "pos_on_r: " << pos_on_r << "\tpos_on_r_saved" << pos_on_r_saved << "\n";
@@ -198,6 +198,7 @@ uint64_t MoveStructure::query_kmers_from_bidirectional(MoveQuery& mq, int32_t& p
             if (partial_match_interval.match_len == k) {
                 // The kmer was found by extending the partial match to left
                 kmers_found += 1;
+                kmer_stats.total_counts += partial_match_interval.fw_interval.count(rlbwt);
                 partial_found += 1;
 
                 kmer_stats.positive_skipped += 1; // c += 1;

--- a/src/test_bidirectional.cpp
+++ b/src/test_bidirectional.cpp
@@ -19,7 +19,7 @@
 
 int main(int argc, char** argv) {
     std::cerr << "\n\n**** The ftab with ftab-k = 12 has to be built.\n";
-    std::cerr << "**** Onlt works with a compact index.\n\n\n";
+    std::cerr << "**** Only works with a compact index.\n\n\n";
 
     MoviOptions movi_options;
     movi_options.set_index_dir(std::string(argv[1]));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -55,3 +55,13 @@ uint64_t kmer_to_number(size_t k, std::string& r, int32_t pos, std::vector<uint6
     }
     return res;
 }
+
+uint8_t F_char(std::vector<uint64_t>& first_runs, uint64_t run) {
+    for (uint8_t i = first_runs.size() - 1; i > 0; i--) {
+        if (run >= first_runs[i]) {
+            return i - 1;
+        }
+    }
+    std::cerr << "Undefined behaviour.\n";
+    exit(0);
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,57 @@
+#include "utils.hpp"
+
+char complement(char c) {
+    // # is the separator, complement(#) = #
+    char c_comp = c == '#' ? '#' : (c == 'A' ? 'T' : ( c == 'C' ? 'G' : (c == 'G' ? 'C' : 'A')));
+    return c_comp;
+}
+
+std::string reverse_complement(std::string& fw) {
+    std::string rc = "";
+    rc.resize(fw.size());
+    for (int i = fw.size() - 1;  i >= 0; i--) {
+        rc[fw.size() - i - 1] = complement(fw[i]);
+    }
+    return rc;
+}
+
+std::string reverse_complement_from_pos(MoveQuery& mq_fw, int32_t pos_on_r, uint64_t match_len) {
+    std::string rc = "";
+    rc.resize(match_len);
+    for (int i = pos_on_r + match_len - 1;  i >= pos_on_r; i--) {
+        rc[pos_on_r + match_len - 1 - i] = complement(mq_fw.query()[i]);
+    }
+    return rc;
+}
+
+std::string number_to_kmer(size_t j, size_t m, std::vector<unsigned char>& alphabet, std::vector<uint64_t>& alphamap) {
+    std::string kmer = "";
+    for (int i = m - 2; i >= 0; i -= 2) {
+        size_t pair = (j >> i) & 0b11;
+        // std::cerr << i << " " << pair << " ";
+        kmer += alphabet[pair + alphamap['A']];
+    }
+    return kmer;
+}
+
+uint64_t kmer_to_number(size_t k, std::string& r, int32_t pos, std::vector<uint64_t>& alphamap, bool rc) {
+    if (r.length() < k) {
+        std::cerr << "The k does not match the kmer length!\n";
+        exit(0);
+    }
+
+    uint64_t res = 0;
+    for (size_t i = 0; i < k; i++) {
+        if (alphamap[static_cast<uint64_t>(r[pos + i])] == alphamap.size()) {
+            return std::numeric_limits<uint64_t>::max();
+        }
+        if (rc) {
+            uint64_t char_code = alphamap[complement(r[pos + i])] - alphamap['A'];
+            res = (char_code << ((i)*2)) | res;
+        } else {
+            uint64_t char_code = alphamap[r[pos + i]] - alphamap['A'];
+            res = (char_code << ((k-i-1)*2)) | res;
+        }
+    }
+    return res;
+}


### PR DESCRIPTION
This is a mode that was called the tally mode in the branch, that refers to keeping the id samples like the way the tally arrays in the FM-index are sampled and stored.