### PR TITLE
MEM Finding Mode

### DIFF
--- a/include/mem_finder.hpp
+++ b/include/mem_finder.hpp
@@ -1,66 +1,6 @@
 #ifndef MEM_FINDER_HPP
 #define MEM_FINDER_HPP
 
-// struct MEMStatistics {
-//     uint64_t total_steps() {
-//         return ftab_backward_extensions + ftab_forward_extensions + ftab_bidirectional_extensions + 
-//                 backward_extensions + forward_extensions + bidirectional_left_extensions + bidirectional_right_extensions;
-//     }
 
-//     uint64_t total_bidirectional_extensions() {
-//         return bidirectional_left_extensions + bidirectional_right_extensions;
-//     }
-    
-//     void print() {
-//         std::cout << "\n\nNumber of MEMs found in the index:\t" << mems << "\n";
-//         std::cout << "Total length of patterns:             \t" << total_length << "\n";
-//         std::cout << "Sum of the counts of found MEMs:      \t" << total_counts << "\n\n\n";
-
-//         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
-//         std::cout << "ftab_skips:               \t" << ftab_skips << "\n";
-//         std::cout << "ftab_backward_fail:       \t" << ftab_backward_fail << "\n";
-//         std::cout << "ftab_forward_fail:        \t" << ftab_forward_fail << "\n";
-//         std::cout << "ftab_bidirectional_fail:  \t" << ftab_bidirectional_fail << "\n";
-//         std::cout << "bidirectional_count_scans:\t" << bidirectional_count_scans << "\t("
-//                     << std::setprecision(4) << static_cast<double>(bidirectional_count_scans) / static_cast<double>(total_bidirectional_extensions()) << " avg.)\n";
-//         std::cout << "bml_skips:                \t" << bml_skips << "\n";
-//         std::cout << "bml_chars_skipped:        \t" << bml_chars_skipped << "\n\n\n";
-        
-//         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
-//         std::cout << "total_steps:                   \t" << total_steps() << "\n";
-//         std::cout << "ftab_backward_extensions:      \t" << ftab_backward_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_backward_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "ftab_forward_extensions:       \t" << ftab_forward_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_forward_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "ftab_bidirectional_extensions: \t" << ftab_bidirectional_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_bidirectional_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "backward_extensions:           \t" << backward_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(backward_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "forward_extensions:            \t" << forward_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(forward_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "bidirectional_left_extensions: \t" << bidirectional_left_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(bidirectional_left_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "bidirectional_right_extensions:\t" << bidirectional_right_extensions << "\t"
-//                     << std::setprecision(4) << 100 * static_cast<double>(bidirectional_right_extensions) / static_cast<double>(total_steps()) << "%\n";
-//         std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
-//     }
-//     uint64_t mems = 0;
-//     uint64_t total_length = 0;
-//     uint64_t total_counts = 0;
-//     uint64_t ftab_skips = 0;
-//     uint64_t ftab_backward_fail = 0;
-//     uint64_t ftab_forward_fail = 0;
-//     uint64_t ftab_bidirectional_fail = 0;
-//     uint64_t bml_skips = 0;
-//     uint64_t bml_chars_skipped = 0;
-//     uint64_t ftab_backward_extensions = 0;
-//     uint64_t ftab_forward_extensions = 0;
-//     uint64_t ftab_bidirectional_extensions = 0;
-//     uint64_t backward_extensions = 0;
-//     uint64_t forward_extensions = 0;
-//     uint64_t bidirectional_left_extensions = 0;
-//     uint64_t bidirectional_right_extensions = 0;
-//     uint64_t bidirectional_count_scans = 0;
-// };
 
 #endif

--- a/include/mem_finder.hpp
+++ b/include/mem_finder.hpp
@@ -1,6 +1,66 @@
 #ifndef MEM_FINDER_HPP
 #define MEM_FINDER_HPP
 
+struct MEMStatistics {
+    uint64_t total_steps() {
+        return ftab_backward_extensions + ftab_forward_extensions + ftab_bidirectional_extensions + 
+                backward_extensions + forward_extensions + bidirectional_left_extensions + bidirectional_right_extensions;
+    }
 
+    uint64_t total_bidirectional_extensions() {
+        return bidirectional_left_extensions + bidirectional_right_extensions;
+    }
+    
+    void print() {
+        std::cout << "\n\nNumber of MEMs found in the index:\t" << mems << "\n";
+        std::cout << "Total length of patterns:             \t" << total_length << "\n";
+        std::cout << "Sum of the counts of found MEMs:      \t" << total_counts << "\n\n\n";
+
+        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
+        std::cout << "ftab_skips:               \t" << ftab_skips << "\n";
+        std::cout << "ftab_backward_fail:       \t" << ftab_backward_fail << "\n";
+        std::cout << "ftab_forward_fail:        \t" << ftab_forward_fail << "\n";
+        std::cout << "ftab_bidirectional_fail:  \t" << ftab_bidirectional_fail << "\n";
+        std::cout << "bidirectional_count_scans:\t" << bidirectional_count_scans << "\t("
+                    << std::setprecision(4) << static_cast<double>(bidirectional_count_scans) / static_cast<double>(total_bidirectional_extensions()) << " avg.)\n";
+        std::cout << "bml_skips:                \t" << bml_skips << "\n";
+        std::cout << "bml_chars_skipped:        \t" << bml_chars_skipped << "\n\n\n";
+        
+        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
+        std::cout << "total_steps:                   \t" << total_steps() << "\n";
+        std::cout << "ftab_backward_extensions:      \t" << ftab_backward_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(ftab_backward_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "ftab_forward_extensions:       \t" << ftab_forward_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(ftab_forward_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "ftab_bidirectional_extensions: \t" << ftab_bidirectional_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(ftab_bidirectional_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "backward_extensions:           \t" << backward_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(backward_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "forward_extensions:            \t" << forward_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(forward_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "bidirectional_left_extensions: \t" << bidirectional_left_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(bidirectional_left_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "bidirectional_right_extensions:\t" << bidirectional_right_extensions << "\t"
+                    << std::setprecision(4) << 100 * static_cast<double>(bidirectional_right_extensions) / static_cast<double>(total_steps()) << "%\n";
+        std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
+    }
+    uint64_t mems = 0;
+    uint64_t total_length = 0;
+    uint64_t total_counts = 0;
+    uint64_t ftab_skips = 0;
+    uint64_t ftab_backward_fail = 0;
+    uint64_t ftab_forward_fail = 0;
+    uint64_t ftab_bidirectional_fail = 0;
+    uint64_t bml_skips = 0;
+    uint64_t bml_chars_skipped = 0;
+    uint64_t ftab_backward_extensions = 0;
+    uint64_t ftab_forward_extensions = 0;
+    uint64_t ftab_bidirectional_extensions = 0;
+    uint64_t backward_extensions = 0;
+    uint64_t forward_extensions = 0;
+    uint64_t bidirectional_left_extensions = 0;
+    uint64_t bidirectional_right_extensions = 0;
+    uint64_t bidirectional_count_scans = 0;
+};
 
 #endif

--- a/include/mem_finder.hpp
+++ b/include/mem_finder.hpp
@@ -1,66 +1,66 @@
 #ifndef MEM_FINDER_HPP
 #define MEM_FINDER_HPP
 
-struct MEMStatistics {
-    uint64_t total_steps() {
-        return ftab_backward_extensions + ftab_forward_extensions + ftab_bidirectional_extensions + 
-                backward_extensions + forward_extensions + bidirectional_left_extensions + bidirectional_right_extensions;
-    }
+// struct MEMStatistics {
+//     uint64_t total_steps() {
+//         return ftab_backward_extensions + ftab_forward_extensions + ftab_bidirectional_extensions + 
+//                 backward_extensions + forward_extensions + bidirectional_left_extensions + bidirectional_right_extensions;
+//     }
 
-    uint64_t total_bidirectional_extensions() {
-        return bidirectional_left_extensions + bidirectional_right_extensions;
-    }
+//     uint64_t total_bidirectional_extensions() {
+//         return bidirectional_left_extensions + bidirectional_right_extensions;
+//     }
     
-    void print() {
-        std::cout << "\n\nNumber of MEMs found in the index:\t" << mems << "\n";
-        std::cout << "Total length of patterns:             \t" << total_length << "\n";
-        std::cout << "Sum of the counts of found MEMs:      \t" << total_counts << "\n\n\n";
+//     void print() {
+//         std::cout << "\n\nNumber of MEMs found in the index:\t" << mems << "\n";
+//         std::cout << "Total length of patterns:             \t" << total_length << "\n";
+//         std::cout << "Sum of the counts of found MEMs:      \t" << total_counts << "\n\n\n";
 
-        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
-        std::cout << "ftab_skips:               \t" << ftab_skips << "\n";
-        std::cout << "ftab_backward_fail:       \t" << ftab_backward_fail << "\n";
-        std::cout << "ftab_forward_fail:        \t" << ftab_forward_fail << "\n";
-        std::cout << "ftab_bidirectional_fail:  \t" << ftab_bidirectional_fail << "\n";
-        std::cout << "bidirectional_count_scans:\t" << bidirectional_count_scans << "\t("
-                    << std::setprecision(4) << static_cast<double>(bidirectional_count_scans) / static_cast<double>(total_bidirectional_extensions()) << " avg.)\n";
-        std::cout << "bml_skips:                \t" << bml_skips << "\n";
-        std::cout << "bml_chars_skipped:        \t" << bml_chars_skipped << "\n\n\n";
+//         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
+//         std::cout << "ftab_skips:               \t" << ftab_skips << "\n";
+//         std::cout << "ftab_backward_fail:       \t" << ftab_backward_fail << "\n";
+//         std::cout << "ftab_forward_fail:        \t" << ftab_forward_fail << "\n";
+//         std::cout << "ftab_bidirectional_fail:  \t" << ftab_bidirectional_fail << "\n";
+//         std::cout << "bidirectional_count_scans:\t" << bidirectional_count_scans << "\t("
+//                     << std::setprecision(4) << static_cast<double>(bidirectional_count_scans) / static_cast<double>(total_bidirectional_extensions()) << " avg.)\n";
+//         std::cout << "bml_skips:                \t" << bml_skips << "\n";
+//         std::cout << "bml_chars_skipped:        \t" << bml_chars_skipped << "\n\n\n";
         
-        std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
-        std::cout << "total_steps:                   \t" << total_steps() << "\n";
-        std::cout << "ftab_backward_extensions:      \t" << ftab_backward_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(ftab_backward_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "ftab_forward_extensions:       \t" << ftab_forward_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(ftab_forward_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "ftab_bidirectional_extensions: \t" << ftab_bidirectional_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(ftab_bidirectional_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "backward_extensions:           \t" << backward_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(backward_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "forward_extensions:            \t" << forward_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(forward_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "bidirectional_left_extensions: \t" << bidirectional_left_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(bidirectional_left_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "bidirectional_right_extensions:\t" << bidirectional_right_extensions << "\t"
-                    << std::setprecision(4) << 100 * static_cast<double>(bidirectional_right_extensions) / static_cast<double>(total_steps()) << "%\n";
-        std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
-    }
-    uint64_t mems = 0;
-    uint64_t total_length = 0;
-    uint64_t total_counts = 0;
-    uint64_t ftab_skips = 0;
-    uint64_t ftab_backward_fail = 0;
-    uint64_t ftab_forward_fail = 0;
-    uint64_t ftab_bidirectional_fail = 0;
-    uint64_t bml_skips = 0;
-    uint64_t bml_chars_skipped = 0;
-    uint64_t ftab_backward_extensions = 0;
-    uint64_t ftab_forward_extensions = 0;
-    uint64_t ftab_bidirectional_extensions = 0;
-    uint64_t backward_extensions = 0;
-    uint64_t forward_extensions = 0;
-    uint64_t bidirectional_left_extensions = 0;
-    uint64_t bidirectional_right_extensions = 0;
-    uint64_t bidirectional_count_scans = 0;
-};
+//         std::cout << "\n- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n";
+//         std::cout << "total_steps:                   \t" << total_steps() << "\n";
+//         std::cout << "ftab_backward_extensions:      \t" << ftab_backward_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_backward_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "ftab_forward_extensions:       \t" << ftab_forward_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_forward_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "ftab_bidirectional_extensions: \t" << ftab_bidirectional_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(ftab_bidirectional_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "backward_extensions:           \t" << backward_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(backward_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "forward_extensions:            \t" << forward_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(forward_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "bidirectional_left_extensions: \t" << bidirectional_left_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(bidirectional_left_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "bidirectional_right_extensions:\t" << bidirectional_right_extensions << "\t"
+//                     << std::setprecision(4) << 100 * static_cast<double>(bidirectional_right_extensions) / static_cast<double>(total_steps()) << "%\n";
+//         std::cout << "- - - - - - - - - - - - - -- - - - - - - - - - - - - - - - - -\n\n";
+//     }
+//     uint64_t mems = 0;
+//     uint64_t total_length = 0;
+//     uint64_t total_counts = 0;
+//     uint64_t ftab_skips = 0;
+//     uint64_t ftab_backward_fail = 0;
+//     uint64_t ftab_forward_fail = 0;
+//     uint64_t ftab_bidirectional_fail = 0;
+//     uint64_t bml_skips = 0;
+//     uint64_t bml_chars_skipped = 0;
+//     uint64_t ftab_backward_extensions = 0;
+//     uint64_t ftab_forward_extensions = 0;
+//     uint64_t ftab_bidirectional_extensions = 0;
+//     uint64_t backward_extensions = 0;
+//     uint64_t forward_extensions = 0;
+//     uint64_t bidirectional_left_extensions = 0;
+//     uint64_t bidirectional_right_extensions = 0;
+//     uint64_t bidirectional_count_scans = 0;
+// };
 
 #endif

--- a/include/mem_finder.hpp
+++ b/include/mem_finder.hpp
@@ -1,0 +1,6 @@
+#ifndef MEM_FINDER_HPP
+#define MEM_FINDER_HPP
+
+
+
+#endif

--- a/include/move_query.hpp
+++ b/include/move_query.hpp
@@ -19,6 +19,14 @@ class MoveQuery {
         void add_sa_entries(uint64_t sa_entry) {
             sa_entries.push_back(sa_entry);
         }
+        struct mem_t {
+            uint32_t start;
+            uint32_t end;
+            uint16_t count;
+        };
+        void add_mem(uint32_t start, uint32_t end, uint16_t count) {
+            mems.push_back(mem_t(start, end, count));
+        }
 
         void add_cost(std::chrono::nanoseconds cost) { costs.push_back(cost); }
         void add_scan(uint64_t scan) { scans.push_back(scan); }
@@ -26,6 +34,7 @@ class MoveQuery {
         std::vector<uint16_t>& get_matching_lengths() { return matching_lens; }
         std::string& get_matching_lengths_string() { return matching_lengths_string; }
         std::vector<uint64_t>& get_sa_entries() { return sa_entries; }
+        std::vector<mem_t>& get_mems() { return mems; }
         std::vector<uint16_t>& get_scans() { return scans; }
         std::vector<uint16_t>& get_fastforwards() { return fastforwards; }
         std::vector<std::chrono::nanoseconds>& get_costs() { return costs; }
@@ -43,6 +52,7 @@ class MoveQuery {
         std::string matching_lengths_string = "";
         std::vector<uint64_t> sa_entries;
         std::vector<uint16_t> matching_lens;
+        std::vector<mem_t> mems;
         std::vector<uint16_t> scans;
         std::vector<uint16_t> fastforwards;
         std::vector<std::chrono::nanoseconds> costs;

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -122,6 +122,10 @@ class MoveStructure {
         uint64_t query_kmers_from_bidirectional(MoveQuery& mq, int32_t& pos_on_r);
         uint64_t query_kmers_from(MoveQuery& mq, int32_t& pos_on_r, bool single = false);
 
+        uint64_t query_mems(MoveQuery& mq);
+        bool query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k, int32_t& pos_on_r);
+        uint64_t query_all_mems(MoveQuery& mq);
+
         MoveInterval try_ftab(MoveQuery& mq, int32_t& pos_on_r, uint64_t& match_len, size_t ftab_k, bool rc = false);
         bool look_ahead_ftab(MoveQuery& mq, uint32_t pos_on_r, int32_t& step);
         bool look_ahead_backward_search(MoveQuery& mq, uint32_t pos_on_r, int32_t step);
@@ -133,6 +137,7 @@ class MoveStructure {
         MoveBiInterval initialize_bidirectional_search(MoveQuery& mq, int32_t& pos_on_r, uint64_t& match_len);
 
         bool backward_search_step(char c, MoveInterval& interval);
+        bool forward_search_step(char c, MoveInterval& rc_interval);
         uint64_t backward_search_step(std::string& R, int32_t& pos_on_r, MoveInterval& interval);
         MoveInterval backward_search(std::string& R, int32_t& pos_on_r, MoveInterval interval, int32_t max_length);
         MoveInterval initialize_backward_search(MoveQuery& mq, int32_t& pos_on_r, uint64_t& match_len, bool rc = false);

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -206,7 +206,6 @@ class MoveStructure {
         void set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t value);
 #endif
         KmerStatistics kmer_stats;
-        // MEMStatistics mem_stats;
         friend class ReadProcessor;
         std::vector<MoveRow> get_rlbwt();
     private:

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -206,7 +206,7 @@ class MoveStructure {
         void set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t value);
 #endif
         KmerStatistics kmer_stats;
-        MEMStatistics mem_stats;
+        // MEMStatistics mem_stats;
         friend class ReadProcessor;
         std::vector<MoveRow> get_rlbwt();
     private:

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -123,7 +123,7 @@ class MoveStructure {
         uint64_t query_kmers_from(MoveQuery& mq, int32_t& pos_on_r, bool single = false);
 
         uint64_t query_mems(MoveQuery& mq);
-        bool query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k, int32_t& pos_on_r);
+        bool query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k);
         uint64_t query_all_mems(MoveQuery& mq);
 
         MoveInterval try_ftab(MoveQuery& mq, int32_t& pos_on_r, uint64_t& match_len, size_t ftab_k, bool rc = false);

--- a/include/move_structure.hpp
+++ b/include/move_structure.hpp
@@ -24,6 +24,7 @@
 #include "move_row.hpp"
 #include "move_query.hpp"
 #include "sequitur.hpp"
+#include "mem_finder.hpp"
 #include "utils.hpp"
 
 struct MoveInterval {
@@ -205,6 +206,7 @@ class MoveStructure {
         void set_rlbwt_thresholds(uint64_t idx, uint16_t i, uint16_t value);
 #endif
         KmerStatistics kmer_stats;
+        MEMStatistics mem_stats;
         friend class ReadProcessor;
         std::vector<MoveRow> get_rlbwt();
     private:

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -32,6 +32,7 @@ class MoviOptions {
         bool is_count() { return count_query; }
         bool is_kmer() { return kmer_query; }
         bool is_kmer_count() { return kmer_count; }
+        bool is_mem() { return mem_query; }
         bool is_reverse() { return reverse; }
         bool is_multi_ftab() { return multi_ftab; }
         bool is_classify() { return classify; }
@@ -42,6 +43,7 @@ class MoviOptions {
         size_t get_strands() { return strands; }
         size_t get_threads() { return threads; }
         uint32_t get_k () { return k; }
+        uint32_t get_min_mem_length() { return min_mem_length; }
         uint32_t get_ftab_k () { return ftab_k; }
         uint32_t get_tally_checkpoints () { return tally_checkpoints; }
         uint64_t get_SA_sample_rate() { return SA_sample_rate; }
@@ -66,12 +68,14 @@ class MoviOptions {
         void set_verify(bool verify_) { verify = verify_; }
         void set_random_repositioning(bool random_repositioning_) { random_repositioning = random_repositioning_; }
         void set_get_sa_entries(bool get_sa_entries_) { get_sa_entries = get_sa_entries_; }
-        void set_pml()   { pml_query = true; count_query = false; kmer_query = false; zml_query = false; }
-        void set_zml()   { zml_query = true; pml_query = false; count_query = false; kmer_query = false; }
-        void set_count() { count_query = true; pml_query = false; kmer_query = false; zml_query = false; }
-        void set_kmer()  { kmer_query = true; pml_query = false; count_query = false; zml_query = false; }
+        void set_pml()   { pml_query = true; count_query = false; kmer_query = false; zml_query = false; mem_query = false; }
+        void set_zml()   { zml_query = true; pml_query = false; count_query = false; kmer_query = false; mem_query = false; }
+        void set_count() { count_query = true; pml_query = false; kmer_query = false; zml_query = false; mem_query = false; }
+        void set_kmer()  { kmer_query = true; pml_query = false; count_query = false; zml_query = false; mem_query = false; }
         void set_kmer_count(bool kmer_count_) { kmer_count = kmer_count_; }
+        void set_mem() { mem_query = true; pml_query = false; count_query = false; kmer_query = false; zml_query = false; }
         void set_k(uint32_t k_) { k = k_; }
+        void set_min_mem_length(uint32_t min_mem_length_) { min_mem_length = min_mem_length_; }
         void set_ftab_k(uint32_t ftab_k_) { ftab_k = ftab_k_; }
         void set_tally_checkpoints(uint32_t tally_checkpoints_) { tally_checkpoints = tally_checkpoints_; }
         void set_SA_sample_rate(uint64_t SA_sample_rate_) { SA_sample_rate = SA_sample_rate_; }
@@ -128,12 +132,14 @@ class MoviOptions {
             std::cerr << "count_query:\t" << count_query << "\n";
             std::cerr << "kmer_query:\t" << kmer_query << "\n";
             std::cerr << "kmer_count:\t" << kmer_count << "\n";
+            std::cerr << "mem_query:\t" << mem_query << "\n";
             std::cerr << "reverse:\t" << reverse << "\n";
             std::cerr << "mmap:\t" << mmap << "\n";
             std::cerr << "prefetch:\t" << prefetch << "\n";
             std::cerr << "strands:\t" << strands << "\n";
             std::cerr << "threads:\t" << threads << "\n";
             std::cerr << "k:\t" << k << "\n";
+            std::cerr << "min_mem_length:\t" << min_mem_length << "\n";
             std::cerr << "ftab_k:\t" << ftab_k << "\n";
             std::cerr << "tally_checkpoints:\t" << tally_checkpoints << "\n";
             std::cerr << "SA_sample_rate:\t" << SA_sample_rate << "\n";
@@ -170,12 +176,14 @@ class MoviOptions {
         bool count_query = false;
         bool kmer_query = false;
         bool kmer_count = false;
+        bool mem_query = false;
         bool reverse = false;
         bool mmap = false;
         bool prefetch = true;
         size_t strands = 16;
         size_t threads = 1;
         uint32_t k = 31;
+        uint32_t min_mem_length = 25;
         uint32_t ftab_k = 0;
         uint32_t tally_checkpoints = 20;
         uint64_t SA_sample_rate = 100;

--- a/include/movi_options.hpp
+++ b/include/movi_options.hpp
@@ -72,8 +72,8 @@ class MoviOptions {
         void set_zml()   { zml_query = true; pml_query = false; count_query = false; kmer_query = false; mem_query = false; }
         void set_count() { count_query = true; pml_query = false; kmer_query = false; zml_query = false; mem_query = false; }
         void set_kmer()  { kmer_query = true; pml_query = false; count_query = false; zml_query = false; mem_query = false; }
-        void set_kmer_count(bool kmer_count_) { kmer_count = kmer_count_; }
         void set_mem() { mem_query = true; pml_query = false; count_query = false; kmer_query = false; zml_query = false; }
+        void set_kmer_count(bool kmer_count_) { kmer_count = kmer_count_; }
         void set_k(uint32_t k_) { k = k_; }
         void set_min_mem_length(uint32_t min_mem_length_) { min_mem_length = min_mem_length_; }
         void set_ftab_k(uint32_t ftab_k_) { ftab_k = ftab_k_; }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -87,6 +87,8 @@ void read_thresholds(std::string tmp_filename, sdsl::int_vector<>& thresholds);
 
 void output_matching_lengths(bool to_stdout, std::ofstream& mls_file, std::string read_id, MoveQuery& mq, bool no_output = false);
 
+void output_mems(bool to_stdout, std::ofstream& mems_file, std::string read_id, MoveQuery& mq, bool no_output = false);
+
 void output_counts(bool to_stdout, std::ofstream& count_file, std::string read_id, size_t query_length, int32_t pos_on_r, uint64_t match_count, bool no_output = false);
 
 void output_logs(std::ofstream& costs_file, std::ofstream& scans_file, std::ofstream& fastforwards_file, std::string read_id, MoveQuery& mq, bool no_output = false);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MOVI_SOURCES
     read_processor.cpp
     utils.cpp
     sequitur.cpp
+    mem_finder.cpp
     emperical_null_database.cpp
     movi_parser.cpp
     classifier.cpp

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -10,8 +10,8 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
 
     int32_t pos_on_r = 0; // MEM finding goes left to right
     std::string& query_seq = mq.query();
-    #pragma omp atomic
-    mem_stats.total_length += query_seq.length();
+    // #pragma omp atomic
+    // mem_stats.total_length += query_seq.length();
 
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
@@ -39,32 +39,32 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
     int32_t init_pos = pos_on_r + min_mem_length - 1;
     MoveBiInterval bi_interval;
     bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-    #pragma omp atomic
-    mem_stats.ftab_bidirectional_extensions += match_len;
-    if (match_len <= 1) {
-        #pragma omp atomic
-        ++mem_stats.ftab_bidirectional_fail;
-    }
+    // #pragma omp atomic
+    // // mem_stats.ftab_bidirectional_extensions += match_len;
+    // if (match_len <= 1) {
+    //     #pragma omp atomic
+    //     ++mem_stats.ftab_bidirectional_fail;
+    // }
     // If min_mem_length is at least ftab_k, we skip using BML
     bool ftab_skip = match_len <= 1 && ftab_k <= min_mem_length;
     --init_pos; // Move to next character left of initial match range
 
     if (ftab_skip) {
-        #pragma omp atomic
-        ++mem_stats.ftab_skips;
+        // #pragma omp atomic
+        // ++mem_stats.ftab_skips;
         // If BML skip is known from ftab, find next left end with only backward extension (extend_left slow without ftab)
         MoveInterval fw_interval = bi_interval.fw_interval;
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!backward_search_step(query_seq[init_pos - j], fw_interval)) {
                 pos_on_r = init_pos - j + 1;
-                #pragma omp atomic
-                ++mem_stats.bml_skips;
-                #pragma omp atomic
-                mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
+                // #pragma omp atomic
+                // ++mem_stats.bml_skips;
+                // #pragma omp atomic
+                // mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
-            #pragma omp atomic
-            ++mem_stats.backward_extensions;
+            // #pragma omp atomic
+            // ++mem_stats.backward_extensions;
             ++match_len;
         }
         // Should never reach here
@@ -76,14 +76,14 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!extend_left(query_seq[init_pos - j], bi_interval)) {
                 pos_on_r = init_pos - j + 1;
-                #pragma omp atomic
-                ++mem_stats.bml_skips;
-                #pragma omp atomic
-                mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
+                // #pragma omp atomic
+                // ++mem_stats.bml_skips;
+                // #pragma omp atomic
+                // mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
-            #pragma omp atomic
-            ++mem_stats.bidirectional_left_extensions;
+            // #pragma omp atomic
+            // ++mem_stats.bidirectional_left_extensions;
             ++match_len;
         }
     }
@@ -98,15 +98,15 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
             rc_interval = rc_interval_before_extension;
             break;
         }
-        #pragma omp atomic
-        ++mem_stats.forward_extensions;
+        // #pragma omp atomic
+        // ++mem_stats.forward_extensions;
         ++match_len;
     }
 
-    #pragma omp atomic
-    ++mem_stats.mems;
-    #pragma omp atomic
-    mem_stats.total_counts += rc_interval.count(rlbwt);
+    // #pragma omp atomic
+    // ++mem_stats.mems;
+    // #pragma omp atomic
+    // mem_stats.total_counts += rc_interval.count(rlbwt);
     mq.add_mem(pos_on_r, i, rc_interval.count(rlbwt));
 
     // Backward extension to find next left end of candidate MEM (inclusive)
@@ -118,19 +118,19 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
         match_len = 0;
         MoveInterval fw_interval = initialize_backward_search(mq, init_pos, match_len);
         ++match_len; // TODO: this is still off by one for initialize_backward_search
-        #pragma omp atomic
-        mem_stats.ftab_backward_extensions += match_len;
-        if (match_len <= 1) {
-            #pragma omp atomic
-            ++mem_stats.ftab_backward_fail;
-        }
+        // #pragma omp atomic
+        // mem_stats.ftab_backward_extensions += match_len;
+        // if (match_len <= 1) {
+        //     #pragma omp atomic
+        //     ++mem_stats.ftab_backward_fail;
+        // }
         --init_pos; // Move to next character left of ftab k-mer or character left of initial range if ftab fails
         for (i = 0; i <= init_pos - (pos_on_r + 1); ++i) {
             if (!backward_search_step(query_seq[init_pos - i], fw_interval)) {
                 break;
             }
-            #pragma omp atomic
-            ++mem_stats.backward_extensions;
+            // #pragma omp atomic
+            // ++mem_stats.backward_extensions;
             ++match_len;
         }
     }
@@ -141,8 +141,8 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
 
 uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     std::string& query_seq = mq.query();
-    #pragma omp atomic
-    mem_stats.total_length += query_seq.length();
+    // #pragma omp atomic
+    // mem_stats.total_length += query_seq.length();
     
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
@@ -154,12 +154,12 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     uint64_t match_len = 0; // bases matched so far
     int32_t init_pos = s; 
     MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-    #pragma omp atomic
-    mem_stats.ftab_bidirectional_extensions += match_len;
-    if (match_len <= 1) {
-        #pragma omp atomic
-        ++mem_stats.ftab_bidirectional_fail;
-    }
+    // #pragma omp atomic
+    // mem_stats.ftab_bidirectional_extensions += match_len;
+    // if (match_len <= 1) {
+    //     #pragma omp atomic
+    //     ++mem_stats.ftab_bidirectional_fail;
+    // }
 
     // Forward extension to find right end of MEM (exclusive)
     while (s < query_seq.length()) {
@@ -168,12 +168,12 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         while (s + match_len < query_seq.length() && extend_right(query_seq[s + match_len], bi_interval)) {
             bi_interval_before_extension = bi_interval;
             ++match_len;
-            #pragma omp atomic
-            ++mem_stats.bidirectional_right_extensions;
+            // #pragma omp atomic
+            // ++mem_stats.bidirectional_right_extensions;
         }
         e = s + match_len;
-        #pragma omp atomic
-        mem_stats.total_counts += bi_interval_before_extension.fw_interval.count(rlbwt);
+        // #pragma omp atomic
+        // mem_stats.total_counts += bi_interval_before_extension.fw_interval.count(rlbwt);
         mq.add_mem(s, e, bi_interval_before_extension.fw_interval.count(rlbwt));
 
         // Backward extension to find next MEM start
@@ -181,17 +181,17 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         if (e < query_seq.length()) {
             init_pos = e;
             bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-            #pragma omp atomic
-            mem_stats.ftab_bidirectional_extensions += match_len;
-            if (match_len <= 1) {
-                #pragma omp atomic
-                ++mem_stats.ftab_bidirectional_fail;
-            }
+            // #pragma omp atomic
+            // mem_stats.ftab_bidirectional_extensions += match_len;
+            // if (match_len <= 1) {
+            //     #pragma omp atomic
+            //     ++mem_stats.ftab_bidirectional_fail;
+            // }
             while (extend_left(query_seq[e - match_len], bi_interval)) {
                 bi_interval_before_extension = bi_interval;
                 ++match_len;
-                #pragma omp atomic
-                ++mem_stats.bidirectional_left_extensions;
+                // #pragma omp atomic
+                // ++mem_stats.bidirectional_left_extensions;
             }
             bi_interval = bi_interval_before_extension;
         }

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -1,0 +1,139 @@
+#include <sys/stat.h> 
+
+#include "move_structure.hpp"
+#include "utils.hpp"
+
+// IMPORTANT: For the bidirectional search, the index has to be built with the reverse complement of the reference
+uint64_t MoveStructure::query_mems(MoveQuery& mq) {
+    int32_t min_mem_length = movi_options->get_min_mem_length();
+    // if (min_mem_length <= 1) return query_all_mems(mq);
+
+    int32_t pos_on_r = 0;
+    std::string& query_seq = mq.query();
+
+    size_t ftab_k = movi_options->get_ftab_k();
+    // At the time, the initialization works if ftab with ftab_k exists only
+    // And the multi-ftab strategy must be turned off
+    movi_options->set_multi_ftab(false);
+    
+    uint64_t mems_found = 0;
+
+    do {
+        // std::cerr << "Starting MEM finding at position " << pos_on_r << "\n";
+        mems_found += query_mem_bml(mq, min_mem_length, query_seq, ftab_k, pos_on_r);
+    } while (pos_on_r < query_seq.length());
+
+    return mems_found;
+}
+
+// We search for a MEM in P[pos_on_r..m-1] starting at pos_on_r
+// Returns true if a MEM is found, false otherwise
+bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k, int32_t& pos_on_r) {
+    // Reached end of query sequence
+    if (pos_on_r + min_mem_length > query_seq.length()) {
+        pos_on_r = query_seq.length();
+        return false;
+    }
+
+    uint64_t match_len = 0;
+    int32_t init_pos = pos_on_r + min_mem_length - 1;
+    MoveBiInterval bi_interval;
+    bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+    if (match_len > 0) {
+        --init_pos;
+    }
+    else {
+        std::cerr << "No match with ftab\n";
+    }
+
+    // Backward extension to find if left end permits a sufficiently long MEM, should equal pos_on_r if true
+    for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
+        if (!extend_left(query_seq[init_pos - j], bi_interval)) {
+            pos_on_r = init_pos - j + 1;
+            return false;
+        }
+    }
+
+    // Forward extension to find right end of MEM (exclusive)
+    MoveInterval rc_interval = bi_interval.rc_interval; // We don't need to keep the fw_interval
+    MoveInterval rc_interval_before_extension = rc_interval;
+    size_t i;
+    for (i = pos_on_r + min_mem_length; i < query_seq.length(); ++i) {
+        rc_interval_before_extension = rc_interval;
+        if (!forward_search_step(query_seq[i], rc_interval)) {
+            rc_interval = rc_interval_before_extension;
+            break;
+        }
+    }
+    mq.add_mem(pos_on_r, i, rc_interval.count(rlbwt));
+
+    // Backward extension to find next left end of candidate MEM (inclusive)
+    // TODO: if this extension is at least L, we can skip the first BML step in next recursion
+    size_t end_pos_on_r = i;
+    size_t j;
+    if (end_pos_on_r < query_seq.length()) {
+        init_pos = end_pos_on_r;
+        match_len = 0;
+        MoveInterval fw_interval = initialize_backward_search(mq, init_pos, match_len);
+         if (match_len > 0) {
+            --init_pos;
+        }
+        else {
+            std::cerr << "No match with ftab\n";
+        }
+        for (i = 0; i <= init_pos - (pos_on_r + 1); ++i) {
+            if (!backward_search_step(query_seq[init_pos - i], fw_interval)) {
+                break;
+            }
+        }
+    }
+
+    pos_on_r = (init_pos - i) + 1;
+    return true;
+}
+
+uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
+    std::string& query_seq = mq.query();
+    
+    size_t ftab_k = movi_options->get_ftab_k();
+    // At the time, the initialization works if ftab with ftab_k exists only
+    // And the multi-ftab strategy must be turned off
+    movi_options->set_multi_ftab(false);
+    
+    size_t s = 0;
+    uint64_t init_match_len = 0; // bases matched so far
+    int32_t init_pos_on_r = s;
+    MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos_on_r, init_match_len);
+    // ftab gives no match, reinitialize to do entire forward extension to find right end of MEM
+    if (init_match_len == 0 && ftab_k > 1) {
+        bi_interval = MoveBiInterval();
+        // TODO: MEM stats
+    }
+
+    while (s < query_seq.length()) {
+        // Extend MEM until mismatch
+        MoveBiInterval bi_interval_before_extension;
+        do {
+            bi_interval_before_extension = bi_interval;
+        } while (extend_right(query_seq[s + bi_interval.match_len], bi_interval));
+        size_t e = s + bi_interval_before_extension.match_len;
+        // std::cerr << "Add MEM of length " << e - s << " from " << s << " to " << e << " with " << bi_interval_before_extension.fw_interval.count(rlbwt) << " matches\n";
+        mq.add_mem(s, e, bi_interval_before_extension.fw_interval.count(rlbwt));
+
+        // Backward extension to find next MEM start
+        init_match_len = 0;
+        init_pos_on_r = e;
+        bi_interval = initialize_bidirectional_search(mq, init_pos_on_r, init_match_len);
+        if (init_match_len == 0 && ftab_k > 1) {
+            bi_interval = MoveBiInterval();
+            // TODO: MEM stats
+        }
+        do {
+            bi_interval_before_extension = bi_interval;
+        } while (extend_left(query_seq[e - bi_interval.match_len], bi_interval));
+        s = e - bi_interval_before_extension.match_len + 1;
+        bi_interval = bi_interval_before_extension;
+    }
+
+    return mq.get_mems().size();
+}

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -10,6 +10,8 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
 
     int32_t pos_on_r = 0; // MEM finding goes left to right
     std::string& query_seq = mq.query();
+    #pragma omp atomic
+    mem_stats.total_length += query_seq.length();
 
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
@@ -26,7 +28,7 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
 
 // We search for a MEM in P[pos_on_r..m-1] starting at pos_on_r
 // Returns true if a MEM is found, false otherwise, and updates pos_on_r
-bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k) {
+bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k) {
     // Reached end of query sequence
     if (pos_on_r + min_mem_length > query_seq.length()) {
         pos_on_r = query_seq.length();
@@ -37,18 +39,32 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_
     int32_t init_pos = pos_on_r + min_mem_length - 1;
     MoveBiInterval bi_interval;
     bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+    #pragma omp atomic
+    mem_stats.ftab_bidirectional_extensions += match_len;
+    if (match_len <= 1) {
+        #pragma omp atomic
+        ++mem_stats.ftab_bidirectional_fail;
+    }
     // If min_mem_length is at least ftab_k, we skip using BML
     bool ftab_skip = match_len <= 1 && ftab_k <= min_mem_length;
     --init_pos; // Move to next character left of initial match range
 
     if (ftab_skip) {
+        #pragma omp atomic
+        ++mem_stats.ftab_skips;
         // If BML skip is known from ftab, find next left end with only backward extension (extend_left slow without ftab)
         MoveInterval fw_interval = bi_interval.fw_interval;
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!backward_search_step(query_seq[init_pos - j], fw_interval)) {
                 pos_on_r = init_pos - j + 1;
+                #pragma omp atomic
+                ++mem_stats.bml_skips;
+                #pragma omp atomic
+                mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
+            #pragma omp atomic
+            ++mem_stats.backward_extensions;
             ++match_len;
         }
         // Should never reach here
@@ -60,8 +76,14 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!extend_left(query_seq[init_pos - j], bi_interval)) {
                 pos_on_r = init_pos - j + 1;
+                #pragma omp atomic
+                ++mem_stats.bml_skips;
+                #pragma omp atomic
+                mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
+            #pragma omp atomic
+            ++mem_stats.bidirectional_left_extensions;
             ++match_len;
         }
     }
@@ -76,9 +98,15 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_
             rc_interval = rc_interval_before_extension;
             break;
         }
+        #pragma omp atomic
+        ++mem_stats.forward_extensions;
         ++match_len;
     }
 
+    #pragma omp atomic
+    ++mem_stats.mems;
+    #pragma omp atomic
+    mem_stats.total_counts += rc_interval.count(rlbwt);
     mq.add_mem(pos_on_r, i, rc_interval.count(rlbwt));
 
     // Backward extension to find next left end of candidate MEM (inclusive)
@@ -89,11 +117,20 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_
         init_pos = end_pos_on_r;
         match_len = 0;
         MoveInterval fw_interval = initialize_backward_search(mq, init_pos, match_len);
+        ++match_len; // TODO: this is still off by one for initialize_backward_search
+        #pragma omp atomic
+        mem_stats.ftab_backward_extensions += match_len;
+        if (match_len <= 1) {
+            #pragma omp atomic
+            ++mem_stats.ftab_backward_fail;
+        }
         --init_pos; // Move to next character left of ftab k-mer or character left of initial range if ftab fails
         for (i = 0; i <= init_pos - (pos_on_r + 1); ++i) {
             if (!backward_search_step(query_seq[init_pos - i], fw_interval)) {
                 break;
             }
+            #pragma omp atomic
+            ++mem_stats.backward_extensions;
             ++match_len;
         }
     }
@@ -104,6 +141,8 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r,int32_t& min_
 
 uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     std::string& query_seq = mq.query();
+    #pragma omp atomic
+    mem_stats.total_length += query_seq.length();
     
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
@@ -115,6 +154,12 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     uint64_t match_len = 0; // bases matched so far
     int32_t init_pos = s; 
     MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+    #pragma omp atomic
+    mem_stats.ftab_bidirectional_extensions += match_len;
+    if (match_len <= 1) {
+        #pragma omp atomic
+        ++mem_stats.ftab_bidirectional_fail;
+    }
 
     // Forward extension to find right end of MEM (exclusive)
     while (s < query_seq.length()) {
@@ -123,8 +168,12 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         while (s + match_len < query_seq.length() && extend_right(query_seq[s + match_len], bi_interval)) {
             bi_interval_before_extension = bi_interval;
             ++match_len;
+            #pragma omp atomic
+            ++mem_stats.bidirectional_right_extensions;
         }
         e = s + match_len;
+        #pragma omp atomic
+        mem_stats.total_counts += bi_interval_before_extension.fw_interval.count(rlbwt);
         mq.add_mem(s, e, bi_interval_before_extension.fw_interval.count(rlbwt));
 
         // Backward extension to find next MEM start
@@ -132,9 +181,17 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         if (e < query_seq.length()) {
             init_pos = e;
             bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+            #pragma omp atomic
+            mem_stats.ftab_bidirectional_extensions += match_len;
+            if (match_len <= 1) {
+                #pragma omp atomic
+                ++mem_stats.ftab_bidirectional_fail;
+            }
             while (extend_left(query_seq[e - match_len], bi_interval)) {
                 bi_interval_before_extension = bi_interval;
                 ++match_len;
+                #pragma omp atomic
+                ++mem_stats.bidirectional_left_extensions;
             }
             bi_interval = bi_interval_before_extension;
         }

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -6,9 +6,9 @@
 // IMPORTANT: For the bidirectional search, the index has to be built with the reverse complement of the reference
 uint64_t MoveStructure::query_mems(MoveQuery& mq) {
     int32_t min_mem_length = movi_options->get_min_mem_length();
-    // if (min_mem_length <= 1) return query_all_mems(mq);
+    if (min_mem_length <= 1) return query_all_mems(mq);
 
-    int32_t pos_on_r = 0;
+    int32_t pos_on_r = 0; // MEM finding goes left to right
     std::string& query_seq = mq.query();
 
     size_t ftab_k = movi_options->get_ftab_k();
@@ -17,9 +17,7 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
     movi_options->set_multi_ftab(false);
     
     uint64_t mems_found = 0;
-
     do {
-        // std::cerr << "Starting MEM finding at position " << pos_on_r << "\n";
         mems_found += query_mem_bml(mq, min_mem_length, query_seq, ftab_k, pos_on_r);
     } while (pos_on_r < query_seq.length());
 
@@ -29,6 +27,8 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
 // We search for a MEM in P[pos_on_r..m-1] starting at pos_on_r
 // Returns true if a MEM is found, false otherwise
 bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::string& query_seq, size_t& ftab_k, int32_t& pos_on_r) {
+    std::cerr << "Querying MEM in P[" << pos_on_r << ", " << query_seq.length() << "]\n";
+    
     // Reached end of query sequence
     if (pos_on_r + min_mem_length > query_seq.length()) {
         pos_on_r = query_seq.length();
@@ -39,18 +39,37 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::s
     int32_t init_pos = pos_on_r + min_mem_length - 1;
     MoveBiInterval bi_interval;
     bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-    if (match_len > 0) {
-        --init_pos;
+    // If min_mem_length is at least ftab_k, we skip using BML
+    bool ftab_skip = match_len <= 1 && ftab_k <= min_mem_length;
+    std::cerr << "Ftab match of P[" << init_pos << ", " << init_pos + ftab_k << "] = " << query_seq.substr(init_pos, ftab_k) << " with count " << bi_interval.fw_interval.count(rlbwt) << "\n";
+    --init_pos; // Move to next character left of initial match range
+
+    if (ftab_skip) {
+        std::cerr << "Ftab skip\n";
+        // If BML skip is known from ftab, find next left end with only backward extension (extend_left slow without ftab)
+        MoveInterval fw_interval = bi_interval.fw_interval;
+        for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
+            if (!backward_search_step(query_seq[init_pos - j], fw_interval)) {
+                pos_on_r = init_pos - j + 1;
+                return false;
+            }
+            ++match_len;
+        }
+        // Should never reach here
+        std::cerr << "Extended past failed ftab\n";
+        exit(0);
     }
     else {
-        std::cerr << "No match with ftab\n";
-    }
-
-    // Backward extension to find if left end permits a sufficiently long MEM, should equal pos_on_r if true
-    for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
-        if (!extend_left(query_seq[init_pos - j], bi_interval)) {
-            pos_on_r = init_pos - j + 1;
-            return false;
+        // Backward extension to find if left end permits a sufficiently long MEM, should equal pos_on_r if true
+        for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
+            std::cerr << "Matching P[" << init_pos - j << "] = " << query_seq[init_pos - j] << "\n";
+            if (!extend_left(query_seq[init_pos - j], bi_interval)) {
+                std::cerr << "Failed, moving to " << init_pos - j + 1 << "\n";
+                pos_on_r = init_pos - j + 1;
+                return false;
+            }
+            std::cerr << "Success, count is " << bi_interval.fw_interval.count(rlbwt) << "\n";
+            ++match_len;
         }
     }
 
@@ -64,7 +83,9 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::s
             rc_interval = rc_interval_before_extension;
             break;
         }
+        ++match_len;
     }
+
     mq.add_mem(pos_on_r, i, rc_interval.count(rlbwt));
 
     // Backward extension to find next left end of candidate MEM (inclusive)
@@ -75,16 +96,12 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& min_mem_length, std::s
         init_pos = end_pos_on_r;
         match_len = 0;
         MoveInterval fw_interval = initialize_backward_search(mq, init_pos, match_len);
-         if (match_len > 0) {
-            --init_pos;
-        }
-        else {
-            std::cerr << "No match with ftab\n";
-        }
+        --init_pos; // Move to next character left of ftab k-mer or character left of initial range if ftab fails
         for (i = 0; i <= init_pos - (pos_on_r + 1); ++i) {
             if (!backward_search_step(query_seq[init_pos - i], fw_interval)) {
                 break;
             }
+            ++match_len;
         }
     }
 
@@ -100,39 +117,42 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     // And the multi-ftab strategy must be turned off
     movi_options->set_multi_ftab(false);
     
-    size_t s = 0;
-    uint64_t init_match_len = 0; // bases matched so far
-    int32_t init_pos_on_r = s;
-    MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos_on_r, init_match_len);
-    // ftab gives no match, reinitialize to do entire forward extension to find right end of MEM
-    if (init_match_len == 0 && ftab_k > 1) {
-        bi_interval = MoveBiInterval();
-        // TODO: MEM stats
-    }
+    size_t s = 0; // start, inclusive
+    size_t e = 0; // end, exclusive
+    uint64_t match_len = 0; // bases matched so far
+    int32_t init_pos = s; 
+    MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+    std::cerr << "Ftab match of P[" << init_pos << ", " << init_pos + match_len << "] = " << query_seq.substr(init_pos, match_len) << " with count " << bi_interval.fw_interval.count(rlbwt) << "\n";
 
+    // Forward extension to find right end of MEM (exclusive)
     while (s < query_seq.length()) {
+        std::cerr << "s: " << s << " and e: " << e << "\n";
         // Extend MEM until mismatch
-        MoveBiInterval bi_interval_before_extension;
-        do {
+        MoveBiInterval bi_interval_before_extension = bi_interval;
+        while (s + match_len < query_seq.length() && extend_right(query_seq[s + match_len], bi_interval)) {
+            std::cerr << "Extending right to P[" << s + match_len << "] = " << query_seq[s + match_len] << " with count " << bi_interval.fw_interval.count(rlbwt) << "\n";
             bi_interval_before_extension = bi_interval;
-        } while (extend_right(query_seq[s + bi_interval.match_len], bi_interval));
-        size_t e = s + bi_interval_before_extension.match_len;
-        // std::cerr << "Add MEM of length " << e - s << " from " << s << " to " << e << " with " << bi_interval_before_extension.fw_interval.count(rlbwt) << " matches\n";
+            ++match_len;
+        }
+        e = s + match_len;
+        std::cerr << "Found MEM of length " << e - s << " from " << s << " to " << e << " with " << bi_interval_before_extension.fw_interval.count(rlbwt) << " matches\n";
         mq.add_mem(s, e, bi_interval_before_extension.fw_interval.count(rlbwt));
 
         // Backward extension to find next MEM start
-        init_match_len = 0;
-        init_pos_on_r = e;
-        bi_interval = initialize_bidirectional_search(mq, init_pos_on_r, init_match_len);
-        if (init_match_len == 0 && ftab_k > 1) {
-            bi_interval = MoveBiInterval();
-            // TODO: MEM stats
+        std::cerr << "Query length: " << query_seq.length() << " and e: " << e << "\n";
+        match_len = 0;
+        if (e < query_seq.length()) {
+            init_pos = e;
+            bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
+            std::cerr << "Ftab match (back) of P[" << init_pos << ", " << init_pos + ftab_k << "] = " << query_seq.substr(init_pos, ftab_k) << " with count " << bi_interval.fw_interval.count(rlbwt) << "\n";
+            while (extend_left(query_seq[e - match_len], bi_interval)) {
+                std::cerr << "Extending left to P[" << e - match_len << "] = " << query_seq[e - match_len] << " with count " << bi_interval.fw_interval.count(rlbwt) << "\n";
+                bi_interval_before_extension = bi_interval;
+                ++match_len;
+            }
+            bi_interval = bi_interval_before_extension;
         }
-        do {
-            bi_interval_before_extension = bi_interval;
-        } while (extend_left(query_seq[e - bi_interval.match_len], bi_interval));
-        s = e - bi_interval_before_extension.match_len + 1;
-        bi_interval = bi_interval_before_extension;
+        s = e - match_len + 1;
     }
 
     return mq.get_mems().size();

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -52,8 +52,7 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
             ++match_len;
         }
         // Should never reach here
-        std::cerr << "Extended past failed ftab\n";
-        exit(0);
+        throw std::runtime_error("Extended past failed ftab");
     }
     else {
         // Backward extension to find if left end permits a sufficiently long MEM, should equal pos_on_r if true

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -10,8 +10,6 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
 
     int32_t pos_on_r = 0; // MEM finding goes left to right
     std::string& query_seq = mq.query();
-    // #pragma omp atomic
-    // mem_stats.total_length += query_seq.length();
 
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
@@ -39,32 +37,18 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
     int32_t init_pos = pos_on_r + min_mem_length - 1;
     MoveBiInterval bi_interval;
     bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-    // #pragma omp atomic
-    // // mem_stats.ftab_bidirectional_extensions += match_len;
-    // if (match_len <= 1) {
-    //     #pragma omp atomic
-    //     ++mem_stats.ftab_bidirectional_fail;
-    // }
     // If min_mem_length is at least ftab_k, we skip using BML
     bool ftab_skip = match_len <= 1 && ftab_k <= min_mem_length;
     --init_pos; // Move to next character left of initial match range
 
     if (ftab_skip) {
-        // #pragma omp atomic
-        // ++mem_stats.ftab_skips;
         // If BML skip is known from ftab, find next left end with only backward extension (extend_left slow without ftab)
         MoveInterval fw_interval = bi_interval.fw_interval;
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!backward_search_step(query_seq[init_pos - j], fw_interval)) {
                 pos_on_r = init_pos - j + 1;
-                // #pragma omp atomic
-                // ++mem_stats.bml_skips;
-                // #pragma omp atomic
-                // mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
-            // #pragma omp atomic
-            // ++mem_stats.backward_extensions;
             ++match_len;
         }
         // Should never reach here
@@ -76,14 +60,8 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
         for (size_t j = 0; j <= init_pos - pos_on_r; ++j) {
             if (!extend_left(query_seq[init_pos - j], bi_interval)) {
                 pos_on_r = init_pos - j + 1;
-                // #pragma omp atomic
-                // ++mem_stats.bml_skips;
-                // #pragma omp atomic
-                // mem_stats.bml_chars_skipped += j - (init_pos - pos_on_r);
                 return false;
             }
-            // #pragma omp atomic
-            // ++mem_stats.bidirectional_left_extensions;
             ++match_len;
         }
     }
@@ -98,15 +76,9 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
             rc_interval = rc_interval_before_extension;
             break;
         }
-        // #pragma omp atomic
-        // ++mem_stats.forward_extensions;
         ++match_len;
     }
 
-    // #pragma omp atomic
-    // ++mem_stats.mems;
-    // #pragma omp atomic
-    // mem_stats.total_counts += rc_interval.count(rlbwt);
     mq.add_mem(pos_on_r, i, rc_interval.count(rlbwt));
 
     // Backward extension to find next left end of candidate MEM (inclusive)
@@ -118,19 +90,11 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
         match_len = 0;
         MoveInterval fw_interval = initialize_backward_search(mq, init_pos, match_len);
         ++match_len; // TODO: this is still off by one for initialize_backward_search
-        // #pragma omp atomic
-        // mem_stats.ftab_backward_extensions += match_len;
-        // if (match_len <= 1) {
-        //     #pragma omp atomic
-        //     ++mem_stats.ftab_backward_fail;
-        // }
         --init_pos; // Move to next character left of ftab k-mer or character left of initial range if ftab fails
         for (i = 0; i <= init_pos - (pos_on_r + 1); ++i) {
             if (!backward_search_step(query_seq[init_pos - i], fw_interval)) {
                 break;
             }
-            // #pragma omp atomic
-            // ++mem_stats.backward_extensions;
             ++match_len;
         }
     }
@@ -141,9 +105,7 @@ bool MoveStructure::query_mem_bml(MoveQuery& mq, int32_t& pos_on_r, int32_t& min
 
 uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     std::string& query_seq = mq.query();
-    // #pragma omp atomic
-    // mem_stats.total_length += query_seq.length();
-    
+
     size_t ftab_k = movi_options->get_ftab_k();
     // At the time, the initialization works if ftab with ftab_k exists only
     // And the multi-ftab strategy must be turned off
@@ -154,12 +116,6 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
     uint64_t match_len = 0; // bases matched so far
     int32_t init_pos = s; 
     MoveBiInterval bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-    // #pragma omp atomic
-    // mem_stats.ftab_bidirectional_extensions += match_len;
-    // if (match_len <= 1) {
-    //     #pragma omp atomic
-    //     ++mem_stats.ftab_bidirectional_fail;
-    // }
 
     // Forward extension to find right end of MEM (exclusive)
     while (s < query_seq.length()) {
@@ -168,12 +124,8 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         while (s + match_len < query_seq.length() && extend_right(query_seq[s + match_len], bi_interval)) {
             bi_interval_before_extension = bi_interval;
             ++match_len;
-            // #pragma omp atomic
-            // ++mem_stats.bidirectional_right_extensions;
         }
         e = s + match_len;
-        // #pragma omp atomic
-        // mem_stats.total_counts += bi_interval_before_extension.fw_interval.count(rlbwt);
         mq.add_mem(s, e, bi_interval_before_extension.fw_interval.count(rlbwt));
 
         // Backward extension to find next MEM start
@@ -181,17 +133,9 @@ uint64_t MoveStructure::query_all_mems(MoveQuery& mq) {
         if (e < query_seq.length()) {
             init_pos = e;
             bi_interval = initialize_bidirectional_search(mq, init_pos, match_len);
-            // #pragma omp atomic
-            // mem_stats.ftab_bidirectional_extensions += match_len;
-            // if (match_len <= 1) {
-            //     #pragma omp atomic
-            //     ++mem_stats.ftab_bidirectional_fail;
-            // }
             while (extend_left(query_seq[e - match_len], bi_interval)) {
                 bi_interval_before_extension = bi_interval;
                 ++match_len;
-                // #pragma omp atomic
-                // ++mem_stats.bidirectional_left_extensions;
             }
             bi_interval = bi_interval_before_extension;
         }

--- a/src/mem_finder.cpp
+++ b/src/mem_finder.cpp
@@ -15,6 +15,10 @@ uint64_t MoveStructure::query_mems(MoveQuery& mq) {
     // At the time, the initialization works if ftab with ftab_k exists only
     // And the multi-ftab strategy must be turned off
     movi_options->set_multi_ftab(false);
+
+    if (min_mem_length > ftab_k) {
+        std::cerr << "Warning: Setting minimum MEM (length " << min_mem_length << ") greater than ftab k (" << ftab_k << ") causes a slower MEM search.\n";
+    }
     
     uint64_t mems_found = 0;
     do {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -2813,7 +2813,11 @@ void MoveStructure::print_stats() {
     std::cerr << "end_bwt_idx:\t" << end_bwt_idx << "\n";
 
     for (int i = 0; i < first_runs.size(); i++) {
-        std::cerr << alphabet[i] << "\t" << i << "\t" << first_runs[i] << "\t" << last_runs[i] << "\n";
+        std::cerr << std::string(1, i == 0 ? '$' : alphabet[i-1])
+                  << "\t" << i
+                  << "\t" << first_runs[i] << ":" << first_offsets[i]
+                  << "\t" << last_runs[i]  << ":" << last_offsets[i]
+                  << "\n";
     }
 
     if (original_r != 0) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1698,6 +1698,9 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
             }
             current_run += 1;
             current_offset = 0;
+            if (movi_options->is_mem()) {
+                ++mem_stats.bidirectional_count_scans;
+            }
         }
 
         while (skip != 0) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1730,6 +1730,7 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
     } else {
         return false;
     }
+    // return backward_search_step(c_, fw_interval) && forward_search_step(c_, rc_interval);
 }
 
 bool MoveStructure::extend_left(char c, MoveBiInterval& bi_interval) {
@@ -1827,7 +1828,8 @@ MoveInterval MoveStructure::try_ftab(MoveQuery& mq, int32_t& pos_on_r, uint64_t&
                         mq.add_ml(i, movi_options->is_stdout());
                     }
                 }
-                if (movi_options->is_zml() or movi_options->is_kmer()) {
+                // Shoudn't we always set this?
+                if (movi_options->is_zml() or movi_options->is_kmer() or movi_options->is_mem()) {
                     match_len = ftab_k - 1;
                 }
                 pos_on_r = pos_on_r - ftab_k + 1;
@@ -1917,6 +1919,11 @@ bool MoveStructure::backward_search_step(char c, MoveInterval& interval) {
     } else {
         return false;
     }
+}
+
+// Must be called using reverse interval
+bool MoveStructure::forward_search_step(char c, MoveInterval& rc_interval) {
+    return backward_search_step(complement(c), rc_interval);
 }
 
 uint64_t MoveStructure::backward_search_step(std::string& R, int32_t& pos_on_r, MoveInterval& interval) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1730,7 +1730,6 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
     } else {
         return false;
     }
-    // return backward_search_step(c_, fw_interval) && forward_search_step(c_, rc_interval);
 }
 
 bool MoveStructure::extend_left(char c, MoveBiInterval& bi_interval) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1698,9 +1698,9 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
             }
             current_run += 1;
             current_offset = 0;
-            if (movi_options->is_mem()) {
-                ++mem_stats.bidirectional_count_scans;
-            }
+            // if (movi_options->is_mem()) {
+            //     ++mem_stats.bidirectional_count_scans;
+            // }
         }
 
         while (skip != 0) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1698,9 +1698,6 @@ bool MoveStructure::extend_bidirectional(char c_, MoveInterval& fw_interval, Mov
             }
             current_run += 1;
             current_offset = 0;
-            // if (movi_options->is_mem()) {
-            //     ++mem_stats.bidirectional_count_scans;
-            // }
         }
 
         while (skip != 0) {

--- a/src/move_structure.cpp
+++ b/src/move_structure.cpp
@@ -1851,7 +1851,10 @@ MoveBiInterval MoveStructure::initialize_bidirectional_search(MoveQuery& mq, int
     // Without the following condition, the match_len will be increamented in the following line
     if (match_len == 0) {
         bi_interval.match_len = match_len;
-        return bi_interval;
+        // For MEM we still need to initialize the rc interval
+        if (!movi_options->is_mem()) {
+            return bi_interval;
+        }
     }
     // This is needed because of the way match_len is off by one
     match_len += 1;

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -44,6 +44,11 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
     omp_set_nested(0);
 
     if (!movi_options.no_prefetch()) {
+        if (movi_options.is_mem()) {
+            std::cerr << "MEM finding does not support prefetching.\n";
+            exit(1);
+        }
+
         ReadProcessor rp(movi_options.get_read_file(), mv_, movi_options.get_strands(), movi_options.is_verbose(), movi_options.is_reverse());
 
         std::ifstream input_file;
@@ -80,8 +85,6 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
 #endif
                 } else if (movi_options.is_kmer()) {
                     rp.kmer_search_latency_hiding(movi_options.get_k(), reader);
-                } else if (movi_options.is_mem()) {
-                    std::cerr << "MEM finding does not support prefetching.\n";
                 }
             }
         }

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -39,15 +39,15 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
         mv_.read_ftab();
         std::cerr<<"Ftab was read!\n";
     }
+    if (movi_options.is_mem() and !movi_options.no_prefetch()) {
+        movi_options.set_prefetch(false);
+        std::cerr << "MEM finding does not support prefetching.\n";
+    }
 
     omp_set_num_threads(movi_options.get_threads());
     omp_set_nested(0);
 
     if (!movi_options.no_prefetch()) {
-        if (movi_options.is_mem()) {
-            std::cerr << "MEM finding does not support prefetching.\n";
-            exit(1);
-        }
 
         ReadProcessor rp(movi_options.get_read_file(), mv_, movi_options.get_strands(), movi_options.is_verbose(), movi_options.is_reverse());
 
@@ -256,6 +256,9 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
                 std::cerr << "The count file is closed.\n";
             } else if (movi_options.is_kmer()) {
                 mv_.kmer_stats.print(movi_options.is_kmer_count());
+            }
+            else if (movi_options.is_mem()) {
+                mv_.mem_stats.print();
             }
             if (movi_options.is_classify()) {
                 classifier.close_report_file();

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -258,7 +258,7 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
                 mv_.kmer_stats.print(movi_options.is_kmer_count());
             }
             else if (movi_options.is_mem()) {
-                mv_.mem_stats.print();
+                // mv_.mem_stats.print();
             }
             if (movi_options.is_classify()) {
                 classifier.close_report_file();

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -41,7 +41,7 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
     }
     if (movi_options.is_mem() and !movi_options.no_prefetch()) {
         movi_options.set_prefetch(false);
-        std::cerr << "MEM finding does not support prefetching.\n";
+        std::cerr << "MEM finding does not support prefetching. Continuing with prefetching disabled.\n";
     }
 
     omp_set_num_threads(movi_options.get_threads());

--- a/src/movi.cpp
+++ b/src/movi.cpp
@@ -257,9 +257,6 @@ void query(MoveStructure& mv_, MoviOptions& movi_options) {
             } else if (movi_options.is_kmer()) {
                 mv_.kmer_stats.print(movi_options.is_kmer_count());
             }
-            else if (movi_options.is_mem()) {
-                // mv_.mem_stats.print();
-            }
             if (movi_options.is_classify()) {
                 classifier.close_report_file();
             }

--- a/src/movi_parser.cpp
+++ b/src/movi_parser.cpp
@@ -13,7 +13,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         ("no-header", "Header information in not stored")
         ("d,dbg", "Enable debug mode")
         ("v,verbose", "Enable verbose mode")
-        ("l,logs", "Enable logs");
+        ("logs", "Enable logs");
 
     auto buildOptions = options.add_options("build")
         ("i,index", "Index directory", cxxopts::value<std::string>())
@@ -54,7 +54,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         ("mmap", "Use memory mapping to read the index")
         ("n,no-prefetch", "Disable prefetching for query")
         ("k,k-length", "The length of the kmer", cxxopts::value<uint32_t>())
-        ("L,min-mem-length", "The minimum length of the MEMs", cxxopts::value<uint32_t>())
+        ("l,min-mem-length", "The minimum length of the MEMs", cxxopts::value<uint32_t>())
         ("ftab-k", "The length of the ftba kmer", cxxopts::value<uint32_t>())
         ("multi-ftab", "Use ftabs with smaller k values if the largest one fails")
         ("s,strands", "Number of strands for query", cxxopts::value<int>())

--- a/src/movi_parser.cpp
+++ b/src/movi_parser.cpp
@@ -43,6 +43,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         ("count", "Compute the count queries")
         ("kmer", "Search all the kmers")
         ("kmer-count", "Find the count of every kmer")
+        ("mem", "Compute the maximal exact matches (MEMs)")
         ("sa-entries", "Find the SA entries for each read")
         ("classify", "Classify the reads")
         ("filter", "Filter the reads based on the matching lengths, output the filtered reads to stdout")
@@ -53,6 +54,7 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
         ("mmap", "Use memory mapping to read the index")
         ("n,no-prefetch", "Disable prefetching for query")
         ("k,k-length", "The length of the kmer", cxxopts::value<uint32_t>())
+        ("L,min-mem-length", "The minimum length of the MEMs", cxxopts::value<uint32_t>())
         ("ftab-k", "The length of the ftba kmer", cxxopts::value<uint32_t>())
         ("multi-ftab", "Use ftabs with smaller k values if the largest one fails")
         ("s,strands", "Number of strands for query", cxxopts::value<int>())
@@ -161,11 +163,13 @@ bool parse_command(int argc, char** argv, MoviOptions& movi_options) {
                         movi_options.set_index_dir(result["index"].as<std::string>());
                         movi_options.set_read_file(result["read"].as<std::string>());
                         if (result.count("k") >= 1) { movi_options.set_k(static_cast<uint32_t>(result["k"].as<uint32_t>())); }
+                        if (result.count("min-mem-length") >= 1) { movi_options.set_min_mem_length(static_cast<uint32_t>(result["min-mem-length"].as<uint32_t>())); }
                         if (result.count("ftab-k") >= 1) { movi_options.set_ftab_k(static_cast<uint32_t>(result["ftab-k"].as<uint32_t>())); }
                         if (result.count("bin-width") >= 1) { movi_options.set_bin_width(static_cast<uint32_t>(result["bin-width"].as<uint32_t>())); }
                         if (result.count("multi-ftab") >= 1) { movi_options.set_multi_ftab(true); }
                         if (result.count("kmer") >= 1) { movi_options.set_kmer(); }
                         if (result.count("kmer-count") >= 1) { movi_options.set_kmer(); movi_options.set_kmer_count(true); }
+                        if (result.count("mem") >= 1) { movi_options.set_mem(); }
                         if (result.count("count") >= 1) { movi_options.set_count(); }
                         if (result.count("zml") >= 1) { movi_options.set_zml(); }
                         if (result.count("pml") >= 1) { movi_options.set_pml(); }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -204,6 +204,20 @@ void output_sa_entries(std::ofstream& sa_entries_file, std::string read_id, Move
     }
 }
 
+void output_mems(bool to_stdout, std::ofstream& mems_file, std::string read_id, MoveQuery& mq, bool no_output) {
+    if (!no_output) {
+        if (to_stdout) {
+            for (auto& mem : mq.get_mems()) {
+                std::cout << read_id << "\t" << mem.start << "\t" << mem.end << "\t" << mem.count << "\n";
+            }
+        } else {
+            for (auto& mem : mq.get_mems()) {
+                mems_file << read_id << "\t" << mem.start << "\t" << mem.end << "\t" << mem.count << "\n";
+            }
+        }
+    }
+}
+
 void output_counts(bool to_stdout, std::ofstream& count_file, std::string read_id, size_t query_length, int32_t pos_on_r, uint64_t match_count, bool no_output) {
     if (!no_output) {
         if (to_stdout) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -216,6 +216,12 @@ void output_mems(bool to_stdout, std::ofstream& mems_file, std::string read_id, 
             }
         }
     }
+    // size_t mem_count = 1;
+    // for (auto& mem : mq.get_mems()) {
+    //     mems_file << ">" << read_id << "." << mem_count << "\n";
+    //     mems_file << mq.query().substr(mem.start, mem.end - mem.start) << "\n";
+    //     ++mem_count;
+    // }
 }
 
 void output_counts(bool to_stdout, std::ofstream& count_file, std::string read_id, size_t query_length, int32_t pos_on_r, uint64_t match_count, bool no_output) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -216,12 +216,6 @@ void output_mems(bool to_stdout, std::ofstream& mems_file, std::string read_id, 
             }
         }
     }
-    // size_t mem_count = 1;
-    // for (auto& mem : mq.get_mems()) {
-    //     mems_file << ">" << read_id << "." << mem_count << "\n";
-    //     mems_file << mq.query().substr(mem.start, mem.end - mem.start) << "\n";
-    //     ++mem_count;
-    // }
 }
 
 void output_counts(bool to_stdout, std::ofstream& count_file, std::string read_id, size_t query_length, int32_t pos_on_r, uint64_t match_count, bool no_output) {


### PR DESCRIPTION
MEM finding mode using BML and matching output of ropebwt3.

Tested only with `movi-regular`.

To ensure that flags match that of other tools using BML, the `-l` flag was removed from logs and used for minimum MEM length.

## Summary by Sourcery

Add MEM finding mode using a bidirectional matching algorithm with new CLI support, output handling, and minimal length filtering.

New Features:
- Implement MEM finding mode via bidirectional matching in MoveStructure
- Add --mem flag and min-mem-length option for specifying minimum MEM length
- Support MEM output to file or stdout through new utility and MoveQuery extensions

Enhancements:
- Repurpose -l flag for minimum MEM length and remove its alias for logs
- Automatically disable prefetch when running in MEM mode to prevent unsupported behavior

Build:
- Include mem_finder.cpp in CMakeLists for MEM functionality

Documentation:
- Update CLI parser to document --mem and --min-mem-length options